### PR TITLE
Fail loud on configuration errors across injection and weighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## Unreleased
+
+### Breaking (loud-by-design)
+
+- Misconfigured primary/secondary processes now raise AddProcessFailure instead of terminating the interpreter with exit(0).
+- Weighter initialization mismatches raise ConfigurationError instead of a debug-only assert or printed message; missing secondary types in weighting raise instead of returning empty/zero results.
+- MultiChannelPhaseSpace: channel/weight length mismatches and un-normalized weights raise ConfigurationError at construction or use, instead of silently assigning leftover probability to the last channel; non-convertible measure combinations raise MeasureCompatibilityError instead of a one-shot stderr warning (allow_incompatible=True opts out).
+- Zero or non-finite generation density during weighting raises WeightCalculationError instead of returning an infinite weight. Zero physical density still yields weight 0.
+
+### Physics-affecting fixes
+
+- Event weights are normalized by the realized injected-event count instead of the configured target count (falls back to the configured count when weighting precedes generation).
+- ConvertDensity now rejects non-Decay2Body SolidAngleLab conversions as unconvertible (MeasureCompatibilityError) instead of silently applying the parent-rest-frame two-body boost Jacobian in the wrong frame; Decay2Body SolidAngleLab conversions are unchanged.
+
+### Fixed
+
+
+### Added
+
+- Typed exceptions exported via siren.utilities and registered with RuntimeError base.
+- ConvertDensity pybind binding.
+- Fixed-seed golden-physics regression harness (tests/python/test_golden_regression.py).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Misconfigured primary/secondary processes now raise AddProcessFailure instead of terminating the interpreter with exit(0).
 - Weighter initialization mismatches raise ConfigurationError instead of a debug-only assert or printed message; missing secondary types in weighting raise instead of returning empty/zero results.
 - MultiChannelPhaseSpace: channel/weight length mismatches and un-normalized weights raise ConfigurationError at construction or use, instead of silently assigning leftover probability to the last channel; non-convertible measure combinations raise MeasureCompatibilityError instead of a one-shot stderr warning (allow_incompatible=True opts out).
-- Zero or non-finite generation density during weighting raises WeightCalculationError instead of returning an infinite weight. Zero physical density still yields weight 0.
+- Nonpositive/nonfinite generation probabilities and negative/nonfinite physical probabilities raise WeightCalculationError in event and per-process weighting. Vertex factors are checked before multiplication; inverse-weight and final-weight overflow also raise. Zero physical density still yields weight 0.
 
 ### Physics-affecting fixes
 

--- a/projects/distributions/private/primary/PrimaryExternalDistribution.cxx
+++ b/projects/distributions/private/primary/PrimaryExternalDistribution.cxx
@@ -11,6 +11,7 @@
 
 #include "SIREN/dataclasses/InteractionRecord.h"  // for Interactio...
 #include "SIREN/distributions/DistributionVariable.h"
+#include "SIREN/utilities/Errors.h"               // for WeightCalculationError
 #include "SIREN/utilities/Random.h"               // for SIREN_random
 #include "SIREN/math/Vector3D.h"
 
@@ -328,9 +329,6 @@ void PrimaryExternalDistribution::Sample(
         else if (keys[i_key] == "m") {
             record.SetMass(value);
         }
-        else if (keys[i_key] == "weight") {
-            record.SetInteractionParameter("PrimaryExternalDistribution_weight", value);
-        }
         else {
             record.SetInteractionParameter(keys[i_key], value);
         }
@@ -404,11 +402,15 @@ double PrimaryExternalDistribution::GenerationProbability(std::shared_ptr<siren:
             if (energy >= emin) return gp_it->second;
             return 0;
         }
+        // Records produced by this distribution's own Sample always carry the
+        // cached generation probability when sampling weights are in use; its
+        // absence means the record did not originate here, so the biased density
+        // cannot be recovered.
+        throw siren::utilities::WeightCalculationError(
+            "PrimaryExternalDistribution: missing cached interaction parameter "
+            "\"PrimaryExternalDistribution_gen_prob\"");
     }
     if (energy >= emin) return 1;
-    if (record.interaction_parameters.find("PrimaryExternalDistribution_weight") != record.interaction_parameters.end()) {
-        return record.interaction_parameters.at("PrimaryExternalDistribution_weight");
-    }
     return 0;
 }
 

--- a/projects/injection/CMakeLists.txt
+++ b/projects/injection/CMakeLists.txt
@@ -48,8 +48,12 @@ install(DIRECTORY "${PROJECT_SOURCE_DIR}/projects/injection/public/"
     PATTERN "*.tcc"
 )
 
-#package_add_test(UnitTest_Injector ${PROJECT_SOURCE_DIR}/projects/injection/private/test/Injector_TEST.cxx)
 package_add_test(UnitTest_Weighter ${PROJECT_SOURCE_DIR}/projects/injection/private/test/Weighter_TEST.cxx)
+if(NOT CIBUILDWHEEL)
+    # The injection headers pull in Pybind11Trampoline.h, so this TU needs the
+    # pybind11 headers (header-only; no Python embedding required).
+    target_link_libraries(UnitTest_Weighter pybind11::headers)
+endif()
 package_add_test(UnitTest_PhaseSpaceReview ${PROJECT_SOURCE_DIR}/projects/injection/private/test/PhaseSpaceReview_TEST.cxx)
 if(NOT CIBUILDWHEEL)
     target_link_libraries(UnitTest_PhaseSpaceReview pybind11::headers)
@@ -65,9 +69,11 @@ endif()
 # Skip under cibuildwheel: package_add_test is a no-op there, so the following
 # target_link_libraries would reference a target that was never created.
 if(NOT CIBUILDWHEEL)
+package_add_test(UnitTest_Injector ${PROJECT_SOURCE_DIR}/projects/injection/private/test/Injector_TEST.cxx)
 package_add_test(UnitTest_CharmSerialization ${PROJECT_SOURCE_DIR}/projects/injection/private/test/CharmSerialization_TEST.cxx)
-# The injection headers pull in Pybind11Trampoline.h, so this TU needs the
+# The injection headers pull in Pybind11Trampoline.h, so these TUs need the
 # pybind11 headers (header-only; no Python embedding required).
+target_link_libraries(UnitTest_Injector pybind11::headers)
 target_link_libraries(UnitTest_CharmSerialization pybind11::headers)
 endif()
 package_add_test(UnitTest_TwoBodyKinematics ${PROJECT_SOURCE_DIR}/projects/injection/private/test/TwoBodyKinematics_TEST.cxx)

--- a/projects/injection/private/Injector.cxx
+++ b/projects/injection/private/Injector.cxx
@@ -93,11 +93,39 @@ Injector::Injector(
 
 
 std::shared_ptr<distributions::VertexPositionDistribution> Injector::FindPrimaryVertexDistribution(std::shared_ptr<siren::injection::PrimaryInjectionProcess> process) {
+    // The vertex distribution is identified by what it declares to set,
+    // not by its C++ type: whichever distribution sets the interaction
+    // vertex owns the injection bounds that weighting integrates over. A
+    // distribution that only seeds the initial position (for example a
+    // PrimaryExternalDistribution with x0/y0/z0 columns) or only the
+    // transverse coordinates (PrimaryArea) does not qualify. When several
+    // declare the vertex the last one wins, because distributions sample
+    // in list order and the last to set the vertex finalizes it.
+    std::shared_ptr<distributions::VertexPositionDistribution> vertex_distribution;
+    std::shared_ptr<distributions::VertexPositionDistribution> initial_position_only;
     for(auto distribution : process->GetPrimaryInjectionDistributions()) {
-        distributions::VertexPositionDistribution * raw_ptr = dynamic_cast<distributions::VertexPositionDistribution*>(distribution.get());
-        if(raw_ptr)
-            return std::dynamic_pointer_cast<distributions::VertexPositionDistribution>(distribution);
+        std::set<distributions::DistributionVariable> variables = distribution->SetVariables();
+        std::shared_ptr<distributions::VertexPositionDistribution> position_distribution =
+            std::dynamic_pointer_cast<distributions::VertexPositionDistribution>(distribution);
+        if(variables.count(distributions::DistributionVariable::InteractionVertex)) {
+            if(!position_distribution) {
+                throw(siren::utilities::AddProcessFailure(
+                    "Distribution \"" + distribution->Name() + "\" declares the "
+                    "interaction vertex but is not a VertexPositionDistribution, "
+                    "so it cannot provide injection bounds!"));
+            }
+            vertex_distribution = position_distribution;
+        } else if(position_distribution && variables.count(distributions::DistributionVariable::InitialPosition)) {
+            // An external distribution carrying only the initial position
+            // doubles as a fixed-vertex distribution when nothing downstream
+            // places the vertex.
+            initial_position_only = position_distribution;
+        }
     }
+    if(vertex_distribution)
+        return vertex_distribution;
+    if(initial_position_only)
+        return initial_position_only;
     throw(siren::utilities::AddProcessFailure("No primary vertex distribution specified!"));
 }
 

--- a/projects/injection/private/Injector.cxx
+++ b/projects/injection/private/Injector.cxx
@@ -111,25 +111,13 @@ std::shared_ptr<distributions::SecondaryVertexPositionDistribution> Injector::Fi
 }
 
 void Injector::SetPrimaryProcess(std::shared_ptr<siren::injection::PrimaryInjectionProcess> primary) {
-    std::shared_ptr<distributions::VertexPositionDistribution> vtx_dist;
-    try {
-        vtx_dist = FindPrimaryVertexDistribution(primary);
-    } catch(siren::utilities::AddProcessFailure const & e) {
-        std::cerr << e.what() << std::endl;
-        exit(0);
-    }
+    std::shared_ptr<distributions::VertexPositionDistribution> vtx_dist = FindPrimaryVertexDistribution(primary);
     primary_process = primary;
     primary_position_distribution = vtx_dist;
 }
 
 void Injector::AddSecondaryProcess(std::shared_ptr<siren::injection::SecondaryInjectionProcess> secondary) {
-    std::shared_ptr<distributions::SecondaryVertexPositionDistribution> vtx_dist;
-    try {
-        vtx_dist = FindSecondaryVertexDistribution(secondary);
-    } catch(siren::utilities::AddProcessFailure const & e) {
-        std::cerr << e.what() << std::endl;
-        exit(0);
-    }
+    std::shared_ptr<distributions::SecondaryVertexPositionDistribution> vtx_dist = FindSecondaryVertexDistribution(secondary);
     secondary_processes.push_back(secondary);
     secondary_position_distributions.push_back(vtx_dist);
     secondary_process_map.insert({secondary->GetPrimaryType(), secondary});
@@ -654,20 +642,51 @@ void Injector::ResetInjectedEvents(unsigned int events_to_inject) {
     last_failed_tree_ = siren::dataclasses::InteractionTree();
 }
 
+void Injector::ResetInjectedEvents() {
+    injected_events = 0;
+    injection_attempts = 0;
+    failed_events = 0;
+    last_failure_reason_.clear();
+    last_failed_tree_ = siren::dataclasses::InteractionTree();
+}
+
 Injector::operator bool() const {
     return events_to_inject == 0 or injected_events < events_to_inject;
 }
 
+namespace {
+// Header word marking a version-stamped injector archive; headerless
+// archives begin directly with the EventsToInject payload.
+constexpr std::uint32_t kInjectorArchiveMagic = 0x53494E4A; // "SINJ"
+} // anonymous namespace
+
 void Injector::SaveInjector(std::string const & filename) const {
     std::ofstream os(filename, std::ios::binary);
     ::cereal::BinaryOutputArchive archive(os);
-    this->save(archive,0);
+    std::uint32_t magic = kInjectorArchiveMagic;
+    // Must match CEREAL_CLASS_VERSION(siren::injection::Injector, ...).
+    std::uint32_t version = 1;
+    archive(magic, version);
+    this->save(archive, version);
 }
 
 void Injector::LoadInjector(std::string const & filename) {
+    {
+        std::ifstream is(filename, std::ios::binary);
+        ::cereal::BinaryInputArchive archive(is);
+        std::uint32_t magic = 0;
+        archive(magic);
+        if(magic == kInjectorArchiveMagic) {
+            std::uint32_t version = 0;
+            archive(version);
+            this->load(archive, version);
+            return;
+        }
+    }
+    // Headerless archive: version-0 schema from the first byte.
     std::ifstream is(filename, std::ios::binary);
     ::cereal::BinaryInputArchive archive(is);
-    this->load(archive,0);
+    this->load(archive, 0);
 }
 
 } // namespace injection

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -93,16 +93,25 @@ void Weighter::Initialize() {
                             )
                     );
             } catch(const std::out_of_range& oor) {
-                std::cout << "Out of Range error: " << oor.what() << '\n';
-                std::cout << "Initialization Incomplete: Particle " <<  sec_phys_process->GetPrimaryType() << " does not exist in injector\n";
-                return;
+                std::ostringstream oss;
+                oss << "Weighter::Initialize: secondary physical process (primary type "
+                    << sec_phys_process->GetPrimaryType()
+                    << ") has no matching injector secondary process for injector "
+                    << i << " (" << oor.what() << ") [siren-docs: errors#configuration]";
+                throw siren::utilities::ConfigurationError(oss.str());
             }
         }
         if(injector_sec_process_weighter_map.size() != injector_sec_process_map.size()) {
-            std::cout << "Initialization Incomplete: No one-to-one mapping between injection and physical distributions for injector " << i << "\n";
-            return;
+            std::ostringstream oss;
+            oss << "Weighter::Initialize: no one-to-one mapping between injection ("
+                << injector_sec_process_map.size() << ") and physical ("
+                << injector_sec_process_weighter_map.size()
+                << ") secondary processes for injector " << i
+                << " [siren-docs: errors#configuration]";
+            throw siren::utilities::ConfigurationError(oss.str());
         }
         secondary_process_weighter_maps.push_back(injector_sec_process_weighter_map);
+        ++i;
     }
 }
 

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -8,6 +8,7 @@
 #include <iostream>                                               // for ope...
 #include <set>                                                    // for set
 #include <stdexcept>
+#include <sstream>
 #include <tuple>
 #include <cassert>
 #include <fstream>
@@ -25,6 +26,7 @@
 #include "SIREN/injection/Process.h"                     // for Phy...
 #include "SIREN/injection/WeightingUtils.h"              // for Cro...
 #include "SIREN/math/Vector3D.h"                         // for Vec...
+#include "SIREN/utilities/Errors.h"                       // for Con...
 
 
 #include "SIREN/injection/Injector.h"
@@ -57,7 +59,16 @@ void Weighter::Initialize() {
     primary_process_weighters.reserve(injectors.size());
     secondary_process_weighter_maps.reserve(injectors.size());
     for(auto const & injector : injectors) {
-        assert(primary_physical_process->MatchesHead(injector->GetPrimaryProcess()));
+        if(!primary_physical_process->MatchesHead(injector->GetPrimaryProcess())) {
+            std::ostringstream oss;
+            oss << "Weighter::Initialize: primary physical process (primary type "
+                << primary_physical_process->GetPrimaryType()
+                << ") does not match the injector primary process (primary type "
+                << injector->GetPrimaryProcess()->GetPrimaryType()
+                << ") for injector " << i
+                << " [siren-docs: errors#configuration]";
+            throw siren::utilities::ConfigurationError(oss.str());
+        }
         primary_process_weighters.push_back(std::make_shared<PrimaryProcessWeighter>(PrimaryProcessWeighter(primary_physical_process, injector->GetPrimaryProcess(), detector_model)));
         std::map<siren::dataclasses::ParticleType, std::shared_ptr<SecondaryProcessWeighter>>
             injector_sec_process_weighter_map;
@@ -66,7 +77,14 @@ void Weighter::Initialize() {
         for(auto const & sec_phys_process : secondary_physical_processes) {
             try{
                 std::shared_ptr<siren::injection::SecondaryInjectionProcess> sec_inj_process = injector_sec_process_map.at(sec_phys_process->GetPrimaryType());
-                assert(sec_phys_process->MatchesHead(sec_inj_process)); // make sure cross section collection matches
+                if(!sec_phys_process->MatchesHead(sec_inj_process)) { // make sure cross section collection matches
+                    std::ostringstream oss;
+                    oss << "Weighter::Initialize: secondary physical process (primary type "
+                        << sec_phys_process->GetPrimaryType()
+                        << ") does not match the injector secondary process for injector "
+                        << i << " [siren-docs: errors#configuration]";
+                    throw siren::utilities::ConfigurationError(oss.str());
+                }
                 injector_sec_process_weighter_map[sec_phys_process->GetPrimaryType()] =
                     std::make_shared<SecondaryProcessWeighter>(
                             SecondaryProcessWeighter(
@@ -113,7 +131,14 @@ double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) c
     double inv_weight = 0;
     for(unsigned int idx = 0; idx < injectors.size(); ++idx) {
         double physical_probability = 1.0;
-        double generation_probability = injectors[idx]->EventsToInject();//GenerationProbability(tree);
+        // Seed with the number of events actually injected so the
+        // weight normalizes by the realized sample size.  Fall back to the
+        // requested count when weighting before/without generation (InjectedEvents
+        // still 0), which keeps the requested-count normalization for that case.
+        double generation_probability = injectors[idx]->InjectedEvents();
+        if(injectors[idx]->InjectedEvents() == 0) {
+            generation_probability = injectors[idx]->EventsToInject();
+        }
         for(auto const & datum : tree.tree) {
             std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
             if(datum->is_root()) {
@@ -129,10 +154,33 @@ double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) c
                     physical_probability *= phys_prob;
                     generation_probability *= gen_prob;
                 } catch(const std::out_of_range& oor) {
-                    std::cout << "Out of Range error: " << oor.what() << '\n';
-                    return 0;
+                    std::ostringstream oss;
+                    oss << "Weighter::EventWeight: no secondary process weighter for secondary type "
+                        << datum->record.signature.primary_type
+                        << " in injector " << idx
+                        << " (" << oor.what() << ") [siren-docs: errors#configuration]";
+                    throw siren::utilities::ConfigurationError(oss.str());
                 }
             }
+        }
+        // Weight-calculation guard: a generation_probability that is <= 0 or
+        // non-finite would produce an infinite or NaN weight via the reciprocal
+        // below; a non-finite physical probability is equally unrecoverable.
+        // Both are configuration/physics failures the caller must not silently
+        // absorb.  physical_probability == 0 is NOT caught here: it drives
+        // inv_weight to +inf and yields a legitimate 0.0-weight event.
+        if(generation_probability <= 0.0 || !std::isfinite(generation_probability)
+           || !std::isfinite(physical_probability)) {
+            std::ostringstream oss;
+            oss << "Weighter::EventWeight: unusable probabilities for injector " << idx;
+            if(!tree.tree.empty()) {
+                oss << " (primary type "
+                    << tree.tree.front()->record.signature.primary_type << ")";
+            }
+            oss << ": generation_probability=" << generation_probability
+                << ", physical_probability=" << physical_probability
+                << " [siren-docs: errors#weight-calc]";
+            throw siren::utilities::WeightCalculationError(oss.str());
         }
         inv_weight += generation_probability / physical_probability;
     }
@@ -172,8 +220,12 @@ std::vector<double> Weighter::GetInteractionProbabilities(siren::dataclasses::In
                 bounds = injectors[i_inj]->SecondaryInjectionBounds(datum->record);
                 int_probs.push_back(secondary_process_weighter_maps[i_inj].at(datum->record.signature.primary_type)->InteractionProbability(bounds, datum->record));
             } catch(const std::out_of_range& oor) {
-                std::cout << "Out of Range error: " << oor.what() << '\n';
-                return {};
+                std::ostringstream oss;
+                oss << "Weighter::GetInteractionProbabilities: no secondary process weighter for secondary type "
+                    << datum->record.signature.primary_type
+                    << " in injector " << i_inj
+                    << " (" << oor.what() << ") [siren-docs: errors#configuration]";
+                throw siren::utilities::ConfigurationError(oss.str());
             }
         }
     }
@@ -199,8 +251,12 @@ std::vector<double> Weighter::GetSurvivalProbabilities(siren::dataclasses::Inter
                 std::get<1>(bounds) = std::get<0>(injectors[i_inj]->SecondaryInjectionBounds(datum->record));
                 survival_probs.push_back(secondary_process_weighter_maps[i_inj].at(datum->record.signature.primary_type)->SurvivalProbability(bounds, datum->record));
             } catch(const std::out_of_range& oor) {
-                std::cout << "Out of Range error: " << oor.what() << '\n';
-                return {};
+                std::ostringstream oss;
+                oss << "Weighter::GetSurvivalProbabilities: no secondary process weighter for secondary type "
+                    << datum->record.signature.primary_type
+                    << " in injector " << i_inj
+                    << " (" << oor.what() << ") [siren-docs: errors#configuration]";
+                throw siren::utilities::ConfigurationError(oss.str());
             }
         }
     }

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -138,7 +138,23 @@ double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) c
 
 
     double inv_weight = 0;
+    bool zero_weight = false;
     for(unsigned int idx = 0; idx < injectors.size(); ++idx) {
+        auto check_probabilities = [&](double generation, double physical) {
+            if(generation <= 0.0 || !std::isfinite(generation)
+               || physical < 0.0 || !std::isfinite(physical)) {
+                std::ostringstream oss;
+                oss << "Weighter::EventWeight: unusable probabilities for injector " << idx;
+                if(!tree.tree.empty()) {
+                    oss << " (primary type "
+                        << tree.tree.front()->record.signature.primary_type << ")";
+                }
+                oss << ": generation_probability=" << generation
+                    << ", physical_probability=" << physical
+                    << " [siren-docs: errors#weight-calc]";
+                throw siren::utilities::WeightCalculationError(oss.str());
+            }
+        };
         double physical_probability = 1.0;
         // Seed with the number of events actually injected so the
         // weight normalizes by the realized sample size.  Fall back to the
@@ -150,18 +166,18 @@ double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) c
         }
         for(auto const & datum : tree.tree) {
             std::tuple<siren::math::Vector3D, siren::math::Vector3D> bounds;
+            double phys_prob;
+            double gen_prob;
             if(datum->is_root()) {
                 bounds = injectors[idx]->PrimaryInjectionBounds(datum->record);
-                physical_probability *= primary_process_weighters[idx]->PhysicalProbability(bounds, datum->record);
-                generation_probability *= primary_process_weighters[idx]->GenerationProbability(*datum);
+                phys_prob = primary_process_weighters[idx]->PhysicalProbability(bounds, datum->record);
+                gen_prob = primary_process_weighters[idx]->GenerationProbability(*datum);
             }
             else {
                 try {
                     bounds = injectors[idx]->SecondaryInjectionBounds(datum->record);
-                    double phys_prob = secondary_process_weighter_maps[idx].at(datum->record.signature.primary_type)->PhysicalProbability(bounds, datum->record);
-                    double gen_prob = secondary_process_weighter_maps[idx].at(datum->record.signature.primary_type)->GenerationProbability(*datum);
-                    physical_probability *= phys_prob;
-                    generation_probability *= gen_prob;
+                    phys_prob = secondary_process_weighter_maps[idx].at(datum->record.signature.primary_type)->PhysicalProbability(bounds, datum->record);
+                    gen_prob = secondary_process_weighter_maps[idx].at(datum->record.signature.primary_type)->GenerationProbability(*datum);
                 } catch(const std::out_of_range& oor) {
                     std::ostringstream oss;
                     oss << "Weighter::EventWeight: no secondary process weighter for secondary type "
@@ -171,29 +187,36 @@ double Weighter::EventWeight(siren::dataclasses::InteractionTree const & tree) c
                     throw siren::utilities::ConfigurationError(oss.str());
                 }
             }
+            // Invalid vertex factors must not cancel or hide behind a zero.
+            check_probabilities(gen_prob, phys_prob);
+            physical_probability *= phys_prob;
+            generation_probability *= gen_prob;
         }
-        // Weight-calculation guard: a generation_probability that is <= 0 or
-        // non-finite would produce an infinite or NaN weight via the reciprocal
-        // below; a non-finite physical probability is equally unrecoverable.
-        // Both are configuration/physics failures the caller must not silently
-        // absorb.  physical_probability == 0 is NOT caught here: it drives
-        // inv_weight to +inf and yields a legitimate 0.0-weight event.
-        if(generation_probability <= 0.0 || !std::isfinite(generation_probability)
-           || !std::isfinite(physical_probability)) {
+        check_probabilities(generation_probability, physical_probability);
+        if(physical_probability == 0.0) {
+            // Preserve zero support, but still validate every other injector.
+            zero_weight = true;
+            continue;
+        }
+        inv_weight += generation_probability / physical_probability;
+        if(!std::isfinite(inv_weight)) {
             std::ostringstream oss;
-            oss << "Weighter::EventWeight: unusable probabilities for injector " << idx;
-            if(!tree.tree.empty()) {
-                oss << " (primary type "
-                    << tree.tree.front()->record.signature.primary_type << ")";
-            }
-            oss << ": generation_probability=" << generation_probability
+            oss << "Weighter::EventWeight: inverse weight overflow for injector " << idx
+                << ": generation_probability=" << generation_probability
                 << ", physical_probability=" << physical_probability
                 << " [siren-docs: errors#weight-calc]";
             throw siren::utilities::WeightCalculationError(oss.str());
         }
-        inv_weight += generation_probability / physical_probability;
     }
-    return 1./inv_weight;
+    double weight = zero_weight ? 0.0 : 1.0 / inv_weight;
+    if(!std::isfinite(weight) || weight < 0.0) {
+        std::ostringstream oss;
+        oss << "Weighter::EventWeight: unusable event weight=" << weight
+            << ", inverse_weight=" << inv_weight
+            << " [siren-docs: errors#weight-calc]";
+        throw siren::utilities::WeightCalculationError(oss.str());
+    }
+    return weight;
 }
 
 std::vector<std::shared_ptr<Injector>> const & Weighter::GetInjectors() const {

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -764,7 +764,8 @@ PYBIND11_MODULE(injection,m) {
     .def("FailedEvents",&Injector::FailedEvents)
     .def("GetLastFailureReason",&Injector::GetLastFailureReason)
     .def("GetLastFailedTree",&Injector::GetLastFailedTree, pybind11::return_value_policy::reference_internal)
-    .def("ResetInjectedEvents",&Injector::ResetInjectedEvents)
+    .def("ResetInjectedEvents",overload_cast<unsigned int>(&Injector::ResetInjectedEvents))
+    .def("ResetInjectedEvents",overload_cast<>(&Injector::ResetInjectedEvents))
     .def("GetPhaseSpaces",&Injector::GetPhaseSpaces)
     .def("AccumulateEventToMixtures",&Injector::AccumulateEventToMixtures,
          arg("tree"), arg("weight"), arg("discount_fallback") = true,

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -765,7 +765,8 @@ PYBIND11_MODULE(injection,m) {
     .def("FailedEvents",&Injector::FailedEvents)
     .def("GetLastFailureReason",&Injector::GetLastFailureReason)
     .def("GetLastFailedTree",&Injector::GetLastFailedTree, pybind11::return_value_policy::reference_internal)
-    .def("ResetInjectedEvents",&Injector::ResetInjectedEvents)
+    .def("ResetInjectedEvents",overload_cast<unsigned int>(&Injector::ResetInjectedEvents))
+    .def("ResetInjectedEvents",overload_cast<>(&Injector::ResetInjectedEvents))
     .def("GetPhaseSpaces",&Injector::GetPhaseSpaces)
     .def("AccumulateEventToMixtures",&Injector::AccumulateEventToMixtures,
          arg("tree"), arg("weight"), arg("discount_fallback") = true,

--- a/projects/injection/private/test/Injector_TEST.cxx
+++ b/projects/injection/private/test/Injector_TEST.cxx
@@ -1,464 +1,107 @@
-
-#include <ios>
-#include <cmath>
-#include <math.h>
 #include <memory>
 #include <vector>
-#include <array>
-#include <iostream>
-#include <fstream>
 
 #include <gtest/gtest.h>
 
-#include "SIREN/interactions/CrossSection.h"
-
+#include "SIREN/utilities/Errors.h"
 #include "SIREN/utilities/Random.h"
-#include "SIREN/utilities/Constants.h"
 #include "SIREN/dataclasses/Particle.h"
-#include "SIREN/injection/Injector.h"
-#include "SIREN/injection/RangedSIREN.h"
-#include "SIREN/injection/Weighter.h"
-#include "SIREN/geometry/Geometry.h"
-#include "SIREN/geometry/ExtrPoly.h"
-#include "SIREN/geometry/Sphere.h"
-#include "SIREN/math/EulerQuaternionConversions.h"
-#include "SIREN/geometry/Placement.h"
-
-#include "SIREN/distributions/primary/type/PrimaryInjector.h"
-#include "SIREN/distributions/primary/energy/ModifiedMoyalPlusExponentialEnergyDistribution.h"
-#include "SIREN/distributions/primary/energy/TabulatedFluxDistribution.h"
-#include "SIREN/distributions/primary/direction/FixedDirection.h"
-#include "SIREN/distributions/primary/vertex/RangeFunction.h"
-#include "SIREN/distributions/primary/vertex/DecayRangeFunction.h"
-
+#include "SIREN/detector/DetectorModel.h"
 #include "SIREN/interactions/InteractionCollection.h"
 #include "SIREN/interactions/CrossSection.h"
-#include "SIREN/interactions/HNLDipoleFromTable.h"
+#include "SIREN/interactions/DummyCrossSection.h"
+#include "SIREN/injection/Injector.h"
+#include "SIREN/injection/Process.h"
 
-#define AUSTIN
-
-using namespace siren::math;
-using namespace siren::geometry;
 using namespace siren::detector;
 using namespace siren::injection;
 using namespace siren::dataclasses;
 using namespace siren::interactions;
 using namespace siren::utilities;
-using namespace siren::distributions;
 
-bool z_samp = false;
-bool in_invGeV = true;
-bool inelastic = false;
-bool miniboone = false;
+// ---------------------------------------------------------------------------
+// Fail-loud hardening: Injector process-setup + reset semantics
+//
+// These tests are self-contained (no external data files): they build a
+// minimal PrimaryInjectionProcess over a DummyCrossSection and drive only the
+// process-registration and counter-reset code paths.
+// ---------------------------------------------------------------------------
 
+namespace {
 
-std::string diff_xs(int Z, int A, std::string mHNL) {
-    std::stringstream ss;
-#ifdef AUSTIN
-    ss << "/home/austin/nu-dipole/xsecs/xsec_tables/diff_xsec_y_Enu/";
-#else
-    if(z_samp) ss << "/home/nwkamp/Research/Pheno/Neutrissimos2/Sandbox/xsec_tables_dipoleFF/diff_xsec_z_Enu/";
-    else ss << "/home/nwkamp/Research/Pheno/Neutrissimos2/sources/nu-dipole/xsecs/xsec_tables/diff_xsec_y_Enu/";
-#endif
-    ss << "dxsec_";
-    ss << "Z_" << Z << "_";
-    ss << "A_" << A << "_";
-    ss << "mHNL_" << mHNL;
-    return ss.str();
+// A PrimaryInjectionProcess with an interaction collection but deliberately
+// NO VertexPositionDistribution.  SetPrimaryProcess must reject it.
+std::shared_ptr<PrimaryInjectionProcess> MakeVertexlessPrimaryProcess() {
+    ParticleType primary = ParticleType::NuMu;
+    std::shared_ptr<DummyCrossSection> xs = std::make_shared<DummyCrossSection>();
+    std::vector<std::shared_ptr<CrossSection>> xs_vec = {xs};
+    std::shared_ptr<InteractionCollection> interactions =
+        std::make_shared<InteractionCollection>(primary, xs_vec);
+    std::shared_ptr<PrimaryInjectionProcess> process =
+        std::make_shared<PrimaryInjectionProcess>(primary, interactions);
+    // Intentionally add no distributions at all -> no vertex distribution.
+    return process;
 }
 
-std::string tot_xs(int Z, int A, std::string mHNL) {
-    std::stringstream ss;
-#ifdef AUSTIN
-    ss << "/home/austin/nu-dipole/xsecs/xsec_tables/tot_xsec_Enu/";
-#else
-    ss << "/home/nwkamp/Research/Pheno/Neutrissimos2/Sandbox/xsec_tables_dipoleFF/tot_xsec_Enu/";
-#endif
-    ss << "xsec_";
-    ss << "Z_" << Z << "_";
-    ss << "A_" << A << "_";
-    ss << "mHNL_" << mHNL;
-    return ss.str();
-}
+} // namespace
 
-std::vector<std::array<int, 2>> gen_ZA() {
-    return std::vector<std::array<int, 2>>{
-        {1, 1},
-				{6, 12},
-				{8, 16},
-				{13, 27},
-				{14, 28},
-				{20, 40},
-				{26, 56},
-				{29, 63},
-				{29, 65},
-				{82, 208},
-    };
-}
-
-std::vector<ParticleType> gen_TargetPIDs() {
-    using ParticleType = ParticleType;
-    return std::vector<ParticleType>{
-        ParticleType::HNucleus,
-            ParticleType::C12Nucleus,
-            ParticleType::O16Nucleus,
-            ParticleType::Al27Nucleus,
-            ParticleType::Si28Nucleus,
-            ParticleType::Ca40Nucleus,
-            ParticleType::Fe56Nucleus,
-            ParticleType::Cu63Nucleus,
-            ParticleType::Cu65Nucleus,
-            ParticleType::Pb208Nucleus
-    };
-}
-
-std::vector<std::string> gen_diff_xs_hf(std::string mHNL) {
-    std::vector<std::string> res;
-    for(auto const & za : gen_ZA()) {
-        res.push_back(diff_xs(za[0], za[1], mHNL) + "_hf.dat");
-    }
-    return res;
-}
-
-std::vector<std::string> gen_tot_xs_hf(std::string mHNL) {
-    std::vector<std::string> res;
-    for(auto const & za : gen_ZA()) {
-        res.push_back(tot_xs(za[0], za[1], mHNL) + "_hf.dat");
-    }
-    return res;
-}
-
-std::vector<std::string> gen_diff_xs_hc(std::string mHNL) {
-    std::vector<std::string> res;
-    for(auto const & za : gen_ZA()) {
-        res.push_back(diff_xs(za[0], za[1], mHNL) + "_hc.dat");
-    }
-    return res;
-}
-
-std::vector<std::string> gen_tot_xs_hc(std::string mHNL) {
-    std::vector<std::string> res;
-    for(auto const & za : gen_ZA()) {
-        res.push_back(tot_xs(za[0], za[1], mHNL) + "_hc.dat");
-    }
-    return res;
-}
-
-bool inFiducial(std::array<double,3> & int_vtx, ExtrPoly & fidVol) {
-    Vector3D pos(int_vtx[0], int_vtx[1], int_vtx[2]);
-    Vector3D dir(0,0,1);
-    return fidVol.IsInside(pos,dir);
-}
-
-bool inFiducial(std::array<double,3> & int_vtx, Sphere & fidVol) {
-    Vector3D pos(int_vtx[0], int_vtx[1], int_vtx[2]);
-    Vector3D dir(0,0,1);
-    return fidVol.IsInside(pos,dir);
-}
-
-double ComputeInteractionLengths(std::shared_ptr<DetectorModel const> detector_model, std::shared_ptr<InteractionCollection const> interactions, std::tuple<Vector3D, Vector3D> const & bounds, InteractionRecord const & record) {
-    Vector3D interaction_vertex = record.interaction_vertex;
-    Vector3D direction(
-            record.primary_momentum[1],
-            record.primary_momentum[2],
-            record.primary_momentum[3]);
-    direction.normalize();
-
-    Geometry::IntersectionList intersections = detector_model->GetIntersections(detector_model->GetEarthCoordPosFromDetCoordPos(interaction_vertex), direction);
-	std::map<ParticleType, std::vector<std::shared_ptr<CrossSection>>> const & cross_sections_by_target = interactions->GetCrossSectionsByTarget();
-    std::vector<double> total_cross_sections;
-    std::vector<ParticleType> targets;
-	InteractionRecord fake_record = record;
-	for(auto const & target_xs : cross_sections_by_target) {
-        targets.push_back(target_xs.first);
-		fake_record.target_mass = detector_model->GetTargetMass(target_xs.first);
-		std::vector<std::shared_ptr<CrossSection>> const & xs_list = target_xs.second;
-		double total_xs = 0.0;
-		for(auto const & xs : xs_list) {
-			std::vector<InteractionSignature> signatures = xs->GetPossibleSignaturesFromParents(record.signature.primary_type, target_xs.first);
-			for(auto const & signature : signatures) {
-				fake_record.signature = signature;
-				// Add total cross section
-				total_xs += xs->TotalCrossSection(fake_record);
-			}
-		}
-		total_cross_sections.push_back(total_xs);
-	}
-    std::vector<double> particle_depths = detector_model->GetParticleColumnDepth(intersections, std::get<0>(bounds), std::get<1>(bounds), targets);
-
-    double interaction_depth = 0.0;
-    for(unsigned int i=0; i<targets.size(); ++i) {
-        interaction_depth += particle_depths[i] * total_cross_sections[i];
-    }
-    return interaction_depth;
-}
-
-std::vector<double> p_LE_FHC_nue = {1.94e+00, 9.57e-01, 3.86e-01, 1.38e+01, 1.41e-01};
-std::vector<double> p_LE_FHC_numu = {2.06e+00, 6.52e-01, 3.36e-01, 7.50e+00, 1.19e-01};
-std::vector<double> p_LE_FHC_nuebar = {1.80e+00, 2.95e+00, 3.80e-01, 2.19e+01, 3.12e-01};
-std::vector<double> p_LE_FHC_numubar = {2.75e+00, 2.46e+00, 4.90e-01, 4.44e+00, 5.15e-02};
-
-std::vector<double> p_LE_RHC_nue = {2.25e+00, 4.38e+00, 5.82e-01, 2.33e+02, 1.00e+00};
-std::vector<double> p_LE_RHC_numu = {3.75e+00, 3.04e+00, 5.53e-01, 1.50e+02, 3.11e-14};
-std::vector<double> p_LE_RHC_nuebar = {1.89e+00, 9.06e-01, 3.95e-01, 8.79e+00, 1.02e-01};
-std::vector<double> p_LE_RHC_numubar = {1.95e+00, 6.09e-01, 3.49e-01, 5.74e+00, 8.92e-02};
-
-std::vector<double> p_ME_FHC_numu = {4.65e+00, 1.35e+00, 7.24e-02, 3.07e+00, 4.45e-03};
-
-
-TEST(Injector, Generation)
-{
-    using ParticleType = ParticleType;
-
-#ifdef AUSTIN
-    std::string material_file = "/home/austin/programs/LIDUNE/sources/SIRENDUNE/resources/Detectors/materials/Minerva.dat";
-    std::string detector_file = "/home/austin/programs/LIDUNE/sources/SIRENDUNE/resources/Detectors/densities/PREM_minerva.dat";
-    std::string flux_file = "/home/austin/nu-dipole/fluxes/LE_FHC_numu.txt";
-    z_samp = false;
-    in_invGeV = false;
-#else
-    std::string material_file = "/home/nwkamp/Research/Pheno/Neutrissimos2/sources/SIRENDUNE/resources/Detectors/materials/Minerva.dat";
-    std::string detector_file = "/home/nwkamp/Research/Pheno/Neutrissimos2/sources/SIRENDUNE/resources/Detectors/densities/PREM_minerva.dat";
-    std::string flux_file = "/home/nwkamp/Research/Pheno/Neutrissimos2/Sandbox/NUMI_Flux_Tables/ME_FHC_numu.txt";
-    if(miniboone) {
-			material_file = "/home/nwkamp/Research/Pheno/Neutrissimos2/sources/SIRENDUNE/resources/Detectors/materials/MiniBooNE.dat";
-			detector_file = "/home/nwkamp/Research/Pheno/Neutrissimos2/sources/SIRENDUNE/resources/Detectors/densities/PREM_miniboone.dat";
-			flux_file = "/home/nwkamp/Research/Pheno/Neutrissimos2/Sandbox/BNB_Flux_Tables/BNB_numu_flux.txt";
-			inelastic = true;
-    }
-#endif
-
-    double hnl_mass = 0.4; // in GeV; The HNL mass we are injecting
-    double dipole_coupling = 1.0e-6; // in GeV^-1; the effective dipole coupling strength
-    std::string mHNL = "0.4";
-
-    // Decay parameters used to set the max range when injecting an HNL
-    double HNL_decay_width = std::pow(dipole_coupling,2)*std::pow(hnl_mass,3)/(4*Constants::pi); // in GeV; decay_width = d^2 m^3 / (4 * pi)
-    double n_decay_lengths = 3.0; // Number of decay lengths to consider
-    double max_distance = 240; // Maximum distance, set by distance from MiniBooNE to the decay pipe
-    // This should encompass Minerva, should probably be smaller? Depends on how long Minerva is...
-    double disk_radius = 1.4; // in meters
-    double endcap_length = 5; // in meters
-    if(miniboone) {
-			max_distance = 541;
-			disk_radius = 6.2;
-			endcap_length = 6.2;
-    }
-
-
-    // Events to inject
-    unsigned int events_to_inject = 5e5;
-    ParticleType primary_type = ParticleType::NuMu;
-
-    // Load cross sections
-    std::vector<std::shared_ptr<CrossSection>> cross_sections;
-    std::vector<ParticleType> primary_types = {ParticleType::NuE, ParticleType::NuMu, ParticleType::NuTau};
-    std::vector<ParticleType> target_types = gen_TargetPIDs();
-    std::shared_ptr<HNLDipoleFromTable> hf_xs = std::make_shared<HNLDipoleFromTable>(hnl_mass, dipole_coupling, HNLDipoleFromTable::HelicityChannel::Flipping, z_samp, in_invGeV, inelastic);
-    std::shared_ptr<HNLDipoleFromTable> hc_xs = std::make_shared<HNLDipoleFromTable>(hnl_mass, dipole_coupling, HNLDipoleFromTable::HelicityChannel::Conserving, z_samp, in_invGeV, inelastic);
-    std::vector<std::string> hf_diff_fnames = gen_diff_xs_hf(mHNL);
-    std::vector<std::string> hc_diff_fnames = gen_diff_xs_hc(mHNL);
-    std::vector<std::string> hf_tot_fnames = gen_tot_xs_hf(mHNL);
-    std::vector<std::string> hc_tot_fnames = gen_tot_xs_hc(mHNL);
-    for(unsigned int i=0; i < target_types.size(); ++i) {
-        //std::cerr << hf_diff_fnames[i] << std::endl;
-        hf_xs->AddDifferentialCrossSectionFile(hf_diff_fnames[i], target_types[i]);
-        ////std::cerr << hf_tot_fnames[i] << std::endl;
-        hf_xs->AddTotalCrossSectionFile(hf_tot_fnames[i], target_types[i]);
-        //std::cerr << hc_diff_fnames[i] << std::endl;
-        hc_xs->AddDifferentialCrossSectionFile(hc_diff_fnames[i], target_types[i]);
-        //std::cerr << hc_tot_fnames[i] << std::endl;
-        hc_xs->AddTotalCrossSectionFile(hc_tot_fnames[i], target_types[i]);
-    }
-    cross_sections.push_back(hf_xs);
-    cross_sections.push_back(hc_xs);
-
-    // Load the detector model
+// SetPrimaryProcess with a process that has no vertex/position distribution
+// must reject it with a catchable AddProcessFailure.
+TEST(InjectorHardening, SetPrimaryProcessWithoutVertexDistributionThrows) {
     std::shared_ptr<DetectorModel> detector_model = std::make_shared<DetectorModel>();
-    detector_model->LoadMaterialModel(material_file);
-    detector_model->LoadDetectorModel(detector_file);
+    std::shared_ptr<SIREN_random> random = std::make_shared<SIREN_random>(1234);
 
-    // Setup the primary type and mass
-    //std::shared_ptr<PrimaryInjector> primary_injector = std::make_shared<PrimaryInjector>(primary_type, hnl_mass);
-    std::shared_ptr<PrimaryInjector> primary_injector = std::make_shared<PrimaryInjector>(primary_type, 0);
+    Injector injector(10, detector_model, random);
+    std::shared_ptr<PrimaryInjectionProcess> bad_process =
+        MakeVertexlessPrimaryProcess();
 
-    // Setup power law
-    std::shared_ptr<SIREN_random> random = std::make_shared<SIREN_random>();
+    EXPECT_THROW(injector.SetPrimaryProcess(bad_process),
+                 siren::utilities::AddProcessFailure);
 
-    std::vector<double> moyal_exp_params = p_ME_FHC_numu;
-
-    // Setup NUMI flux
-    std::shared_ptr<ModifiedMoyalPlusExponentialEnergyDistribution> pdf = std::make_shared<ModifiedMoyalPlusExponentialEnergyDistribution>(hnl_mass, 20, moyal_exp_params[0], moyal_exp_params[1], moyal_exp_params[2], moyal_exp_params[3], moyal_exp_params[4]);
-
-    // Setup tabulated flux
-    std::shared_ptr<TabulatedFluxDistribution> tab_pdf = std::make_shared<TabulatedFluxDistribution>(flux_file, true);
-    std::shared_ptr<TabulatedFluxDistribution> tab_pdf_gen = std::make_shared<TabulatedFluxDistribution>(hnl_mass, 10, flux_file);
-
-    // Change the flux units from cm^-2 to m^-2
-    std::shared_ptr<WeightableDistribution> flux_units = std::make_shared<NormalizationConstant>(1e4);
-
-    // Pick energy distribution
-    std::shared_ptr<PrimaryEnergyDistribution> edist = tab_pdf_gen;
-
-    // Choose injection direction
-    std::shared_ptr<PrimaryDirectionDistribution> ddist = std::make_shared<FixedDirection>(Vector3D{0.0, 0.0, 1.0});
-
-    // Let us inject according to the decay distribution
-    std::shared_ptr<RangeFunction> range_func = std::make_shared<DecayRangeFunction>(hnl_mass, HNL_decay_width, n_decay_lengths, max_distance);
-
-    // Helicity distribution
-    std::shared_ptr<PrimaryNeutrinoHelicityDistribution> helicity_distribution = std::make_shared<PrimaryNeutrinoHelicityDistribution>();
-
-    // Put it all together!
-    std::shared_ptr<Injector> injector = std::make_shared<RangedSIREN>(events_to_inject, primary_injector, cross_sections, detector_model, random, edist, ddist, range_func, disk_radius, endcap_length, helicity_distribution);
-
-    std::vector<std::shared_ptr<WeightableDistribution>> physical_distributions = {
-        std::shared_ptr<WeightableDistribution>(tab_pdf),
-        std::shared_ptr<WeightableDistribution>(flux_units),
-        std::shared_ptr<WeightableDistribution>(ddist),
-        std::shared_ptr<WeightableDistribution>(helicity_distribution)
-    };
-
-    LeptonWeighter weighter(std::vector<std::shared_ptr<Injector>>{injector}, detector_model, injector->GetInteractions(), physical_distributions);
-
-    std::vector<std::vector<double>> poly;
-    // MINERvA Fiducial Volume
-    // 88.125 cm apothem
-    //poly.push_back({0.0, 1.01758});
-    //poly.push_back({0.88125, 0.50879});
-    //poly.push_back({0.88125, -0.50879});
-    //poly.push_back({0.0, -1.01758});
-    //poly.push_back({-0.88125, -0.50879});
-    //poly.push_back({-0.88125, 0.50879});
-
-    // 81.125 cm apothem
-    poly.push_back({0.0, 0.93675});
-    poly.push_back({0.81125, 0.46838});
-    poly.push_back({0.81125, -0.46838});
-    poly.push_back({0.0, -0.93675});
-    poly.push_back({-0.81125, -0.46838});
-    poly.push_back({-0.81125, 0.46838});
-
-    double offset[2];
-    offset[0] = 0;
-    offset[1] = 0;
-    std::vector<ExtrPoly::ZSection> zsecs;
-    zsecs.push_back(ExtrPoly::ZSection(1.45,offset,1));
-    zsecs.push_back(ExtrPoly::ZSection(4.0,offset,1));
-    Placement placement(Vector3D(0,0,0), QFromZXZr(0,0,0));
-    ExtrPoly MINERvA_fiducial = ExtrPoly(placement, poly, zsecs);
-
-    // MiniBooNE Fiducial Volume
-    Placement placementMB(Vector3D(0,0,0), QFromZXZr(0,0,0));
-    Sphere MiniBooNE_fiducial = Sphere(placement, 5.0, 0.0);
-
-    std::ofstream myFile("injector_test_events.csv");
-    // myFile << std::fixed << std::setprecision(6);
-    myFile << std::scientific << std::setprecision(16);
-    myFile << "intX intY intZ ";
-    myFile << "decX decY decZ ";
-    myFile << "ppX ppY ppZ ";
-    myFile << "p4nu_0 p4nu_1 p4nu_2 p4nu_3 ";
-    myFile << "helnu ";
-    myFile << "p4itgt_0 p4itgt_1 p4itgt_2 p4itgt_3 ";
-    myFile << "helitgt ";
-    myFile << "p4hnl_0 p4hnl_1 p4hnl_2 p4hnl_3 ";
-    myFile << "helhnl ";
-    myFile << "p4ftgt_0 p4ftgt_1 p4ftgt_2 p4ftgt_3 ";
-    myFile << "helftgt ";
-    myFile << "p4gamma_0 p4gamma_1 p4gamma_2 p4gamma_3 ";
-    myFile << "p4gamma_hnlRest_0 p4gamma_hnlRest_1 p4gamma_hnlRest_2 p4gamma_hnlRest_3 ";
-    myFile << "helgamma ";
-    myFile << "decay_length decay_fid_weight decay_ang_weight prob_nopairprod basic_weight simplified_weight interaction_lengths interaction_prob y target fid\n";
-    myFile << std::endl;
-    int i = 0;
-    while(*injector) {
-        InteractionRecord event = injector->GenerateEvent();
-        DecayRecord decay;
-        InteractionRecord pair_prod;
-        double basic_weight, simplified_weight, interaction_lengths, interaction_prob = 0;
-        if(event.signature.target_type != ParticleType::unknown) {
-            if(miniboone) injector->SampleSecondaryDecay(event, decay, HNL_decay_width, 1, 0, &MiniBooNE_fiducial, 0.1);
-            else injector->SampleSecondaryDecay(event, decay, HNL_decay_width, 1, 0, &MINERvA_fiducial, 1.0);
-            //injector->SamplePairProduction(decay, pair_prod);
-            //basic_weight = weighter.EventWeight(event);
-            simplified_weight = weighter.SimplifiedEventWeight(event);
-            interaction_lengths = ComputeInteractionLengths(detector_model, injector->GetInteractions(), injector->InjectionBounds(event), event);
-            interaction_prob = weighter.InteractionProbability(injector->InjectionBounds(event), event);
-        }
-        if(event.secondary_momenta.size() > 0) {
-            myFile << event.interaction_vertex[0] << " ";
-            myFile << event.interaction_vertex[1] << " ";
-            myFile << event.interaction_vertex[2] << " ";
-
-            myFile << decay.decay_vertex[0] << " ";
-            myFile << decay.decay_vertex[1] << " ";
-            myFile << decay.decay_vertex[2] << " ";
-
-            myFile << pair_prod.interaction_vertex[0] << " ";
-            myFile << pair_prod.interaction_vertex[1] << " ";
-            myFile << pair_prod.interaction_vertex[2] << " ";
-
-            myFile << event.primary_momentum[0] << " ";
-            myFile << event.primary_momentum[1] << " ";
-            myFile << event.primary_momentum[2] << " ";
-            myFile << event.primary_momentum[3] << " ";
-
-            myFile << event.primary_helicity << " ";
-
-            myFile << event.target_helicity << " ";
-
-            myFile << event.secondary_momenta[0][0] << " ";
-            myFile << event.secondary_momenta[0][1] << " ";
-            myFile << event.secondary_momenta[0][2] << " ";
-            myFile << event.secondary_momenta[0][3] << " ";
-
-            myFile << event.secondary_helicities[0] << " ";
-
-            myFile << event.secondary_momenta[1][0] << " ";
-            myFile << event.secondary_momenta[1][1] << " ";
-            myFile << event.secondary_momenta[1][2] << " ";
-            myFile << event.secondary_momenta[1][3] << " ";
-
-            myFile << event.secondary_helicities[1] << " ";
-
-            myFile << decay.secondary_momenta[0][0] << " ";
-            myFile << decay.secondary_momenta[0][1] << " ";
-            myFile << decay.secondary_momenta[0][2] << " ";
-            myFile << decay.secondary_momenta[0][3] << " ";
-
-            myFile << decay.secondary_momenta[1][0] << " ";
-            myFile << decay.secondary_momenta[1][1] << " ";
-            myFile << decay.secondary_momenta[1][2] << " ";
-            myFile << decay.secondary_momenta[1][3] << " ";
-
-            myFile << decay.secondary_helicities[0] << " ";
-
-            myFile << decay.decay_parameters[3] << " "; // decay enter
-            myFile << decay.decay_parameters[4] << " "; // decay exit
-            myFile << decay.decay_parameters[0] << " "; // decay length
-            myFile << decay.decay_parameters[1] << " "; // decay fid weight
-            myFile << decay.decay_parameters[2] << " "; // decay anglular weight
-            myFile << pair_prod.interaction_parameters[0] << " "; // probability of no pair production
-            myFile << basic_weight << " ";
-            myFile << simplified_weight << " ";
-            myFile << interaction_lengths << " ";
-            myFile << interaction_prob << " ";
-            myFile << event.interaction_parameters[1] << " "; // sampled y
-            myFile << event.signature.target_type << " "; // target type
-            if(miniboone) myFile << int(inFiducial(pair_prod.interaction_vertex, MiniBooNE_fiducial)) << "\n"; // fid vol
-            else myFile << int(inFiducial(pair_prod.interaction_vertex, MINERvA_fiducial)) << "\n"; // fid vol
-            myFile << "\n";
-        }
-        if((++i) % (events_to_inject/10)==0)
-            std::cerr << (int)(i*100 / (events_to_inject)) << "%" << std::endl;
-    }
-    myFile.close();
+    // The thrown type is also a std::runtime_error (backward-compat contract:
+    // every SIREN typed exception derives from runtime_error).
+    EXPECT_THROW(injector.SetPrimaryProcess(bad_process), std::runtime_error);
 }
 
-int main(int argc, char** argv)
-{
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+// The constructor that takes a primary process routes through SetPrimaryProcess,
+// so a vertexless process must make construction throw rather than exit(0).
+TEST(InjectorHardening, ConstructWithVertexlessPrimaryProcessThrows) {
+    std::shared_ptr<DetectorModel> detector_model = std::make_shared<DetectorModel>();
+    std::shared_ptr<SIREN_random> random = std::make_shared<SIREN_random>(1234);
+    std::shared_ptr<PrimaryInjectionProcess> bad_process =
+        MakeVertexlessPrimaryProcess();
+
+    EXPECT_THROW(
+        Injector(10, detector_model, bad_process, random),
+        siren::utilities::AddProcessFailure);
 }
 
+// The zero-arg ResetInjectedEvents() overload keeps the
+// injection quota (EventsToInject) while clearing the run counters.  The
+// counted overload changes the quota.  This pins the two overloads' distinct
+// contracts without needing a full generation chain: after the counted reset
+// sets a known quota, the zero-arg reset must preserve it.
+TEST(InjectorHardening, ResetInjectedEventsZeroArgPreservesQuota) {
+    std::shared_ptr<DetectorModel> detector_model = std::make_shared<DetectorModel>();
+    std::shared_ptr<SIREN_random> random = std::make_shared<SIREN_random>(1234);
+    Injector injector(0, detector_model, random);
+
+    // Counted overload sets a new quota and clears counters.
+    injector.ResetInjectedEvents(777);
+    EXPECT_EQ(injector.EventsToInject(), 777u);
+    EXPECT_EQ(injector.InjectionAttempts(), 0u);
+    EXPECT_EQ(injector.InjectedEvents(), 0u);
+
+    // Zero-arg overload preserves the quota and clears the run counters.
+    injector.ResetInjectedEvents();
+    EXPECT_EQ(injector.EventsToInject(), 777u)
+        << "zero-arg ResetInjectedEvents() must not change the quota";
+    EXPECT_EQ(injector.InjectionAttempts(), 0u);
+    EXPECT_EQ(injector.InjectedEvents(), 0u);
+
+    // Counted overload can still change the quota afterwards.
+    injector.ResetInjectedEvents(3);
+    EXPECT_EQ(injector.EventsToInject(), 3u);
+    injector.ResetInjectedEvents();
+    EXPECT_EQ(injector.EventsToInject(), 3u);
+}

--- a/projects/injection/private/test/Weighter_TEST.cxx
+++ b/projects/injection/private/test/Weighter_TEST.cxx
@@ -1,14 +1,27 @@
 #include <cmath>
+#include <memory>
 #include <stdexcept>
+#include <vector>
 
 #include <gtest/gtest.h>
 
-// Forward-declare the helper functions from Weighter.tcc (linked via SIREN lib)
-// to avoid ODR violations from including the full header.
-namespace siren { namespace injection {
-    double one_minus_exp_of_negative(double x);
-    double log_one_minus_exp_of_negative(double x);
-}}
+#include "SIREN/dataclasses/InteractionRecord.h"
+#include "SIREN/dataclasses/InteractionTree.h"
+#include "SIREN/dataclasses/Particle.h"
+#include "SIREN/dataclasses/VertexWeightingMode.h"
+#include "SIREN/detector/ConstantDensityDistribution.h"
+#include "SIREN/detector/DetectorModel.h"
+#include "SIREN/distributions/Distributions.h"
+#include "SIREN/distributions/primary/vertex/SphereVolumePositionDistribution.h"
+#include "SIREN/geometry/Sphere.h"
+#include "SIREN/injection/Injector.h"
+#include "SIREN/injection/Process.h"
+#include "SIREN/injection/Weighter.h"
+#include "SIREN/interactions/CrossSection.h"
+#include "SIREN/interactions/DummyCrossSection.h"
+#include "SIREN/interactions/InteractionCollection.h"
+#include "SIREN/utilities/Errors.h"
+#include "SIREN/utilities/Random.h"
 
 using namespace siren::injection;
 
@@ -108,4 +121,120 @@ TEST(WeighterHelpers, LogOneMinusExpIsNegative) {
         double result = log_one_minus_exp_of_negative(x);
         EXPECT_LT(result, 0.0) << "Failed at x=" << x;
     }
+}
+
+// ---------------------------------------------------------------------------
+// Weighter::EventWeight guard behavior
+//
+// Both fixtures below use VertexWeightingMode::Fixed() on the injection and
+// physical process, so InteractionProbability and NormalizedPositionProbability
+// (which integrate density along the path) are never evaluated. Only the
+// channel-selection and final-state-density factors are, and both reduce to
+// an exact 1.0 for this single-channel DummyCrossSection with a matching
+// signature, so the per-vertex generation/physical probabilities are
+// predictable and the two guard branches can be pinned exactly.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct WeighterGuardFixture {
+    std::shared_ptr<siren::injection::Injector> injector;
+    std::shared_ptr<siren::injection::Weighter> weighter;
+    siren::dataclasses::InteractionTree tree;
+};
+
+// `events_to_inject` seeds the realized-count normalization: Weighter reads
+// EventsToInject() while InjectedEvents() is still 0 (i.e. before any
+// generation). `zero_physical_normalization` adds a NormalizationConstant(0.0)
+// to the physical process; PhysicalProbability multiplies its result by that
+// distribution's normalization, so it becomes exactly 0.0 without perturbing
+// GenerationProbability, which never applies the physical normalization.
+WeighterGuardFixture BuildWeighterGuardFixture(unsigned int events_to_inject,
+                                                bool zero_physical_normalization) {
+    siren::dataclasses::ParticleType primary_type = siren::dataclasses::ParticleType::NuMu;
+    siren::dataclasses::ParticleType target_type = siren::dataclasses::ParticleType::Nucleon;
+
+    std::shared_ptr<siren::detector::DetectorModel> detector_model =
+        std::make_shared<siren::detector::DetectorModel>();
+    detector_model->ClearSectors();
+    siren::detector::DetectorSector world;
+    world.name = "world";
+    world.material_id = 0;  // default "VACUUM" material (real nucleon content)
+    world.level = 0;
+    world.geo = siren::geometry::Sphere(100.0, 0.0).create();
+    world.density = siren::detector::ConstantDensityDistribution(1.0).create();
+    detector_model->AddSector(world);
+
+    std::shared_ptr<siren::interactions::DummyCrossSection> xs =
+        std::make_shared<siren::interactions::DummyCrossSection>();
+    std::vector<std::shared_ptr<siren::interactions::CrossSection>> xs_vec = {xs};
+    std::shared_ptr<siren::interactions::InteractionCollection> int_col =
+        std::make_shared<siren::interactions::InteractionCollection>(primary_type, xs_vec);
+
+    std::shared_ptr<siren::injection::PrimaryInjectionProcess> primary_inj =
+        std::make_shared<siren::injection::PrimaryInjectionProcess>(primary_type, int_col);
+    primary_inj->SetWeightingMode(siren::dataclasses::VertexWeightingMode::Fixed());
+    primary_inj->AddPrimaryInjectionDistribution(
+        std::make_shared<siren::distributions::SphereVolumePositionDistribution>(
+            siren::geometry::Sphere(50.0, 0.0)));
+
+    std::shared_ptr<siren::injection::PhysicalProcess> primary_phys =
+        std::make_shared<siren::injection::PhysicalProcess>(primary_type, int_col);
+    primary_phys->SetWeightingMode(siren::dataclasses::VertexWeightingMode::Fixed());
+    if (zero_physical_normalization) {
+        primary_phys->AddPhysicalDistribution(
+            std::make_shared<siren::distributions::NormalizationConstant>(0.0));
+    }
+
+    std::shared_ptr<siren::utilities::SIREN_random> random =
+        std::make_shared<siren::utilities::SIREN_random>(1234);
+    std::shared_ptr<siren::injection::Injector> injector =
+        std::make_shared<siren::injection::Injector>(
+            events_to_inject, detector_model, primary_inj,
+            std::vector<std::shared_ptr<siren::injection::SecondaryInjectionProcess>>{},
+            random);
+
+    std::shared_ptr<siren::injection::Weighter> weighter =
+        std::make_shared<siren::injection::Weighter>(
+            std::vector<std::shared_ptr<siren::injection::Injector>>{injector},
+            detector_model, primary_phys,
+            std::vector<std::shared_ptr<siren::injection::PhysicalProcess>>{});
+
+    siren::dataclasses::InteractionRecord record;
+    record.signature.primary_type = primary_type;
+    record.signature.target_type = target_type;
+    record.signature.secondary_types = {primary_type, target_type};
+    record.primary_mass = 0.0;
+    record.primary_momentum = {2.0, 0.0, 0.0, 2.0};
+    record.interaction_vertex = {0.0, 0.0, 10.0};
+
+    siren::dataclasses::InteractionTree tree;
+    tree.add_entry(record);
+
+    return WeighterGuardFixture{injector, weighter, tree};
+}
+
+} // namespace
+
+// generation_probability <= 0 (here: EventsToInject() == 0, the realized-count
+// seed used before any generation) must raise WeightCalculationError rather
+// than let the reciprocal in EventWeight blow up silently.
+TEST(WeighterGuards, GenerationProbabilityNonpositiveThrowsWeightCalculationError) {
+    WeighterGuardFixture fixture = BuildWeighterGuardFixture(
+        /*events_to_inject=*/0, /*zero_physical_normalization=*/false);
+    EXPECT_EQ(fixture.injector->InjectedEvents(), 0u);
+    EXPECT_EQ(fixture.injector->EventsToInject(), 0u);
+    EXPECT_THROW(fixture.weighter->EventWeight(fixture.tree),
+                 siren::utilities::WeightCalculationError);
+}
+
+// physical_probability == 0 (here: a NormalizationConstant(0.0) on the
+// physical process) must yield an exact 0.0 weight without raising --
+// distinct from the generation-side guard above.
+TEST(WeighterGuards, PhysicalProbabilityZeroGivesZeroWeightWithoutThrowing) {
+    WeighterGuardFixture fixture = BuildWeighterGuardFixture(
+        /*events_to_inject=*/100, /*zero_physical_normalization=*/true);
+    double weight = 0.0;
+    EXPECT_NO_THROW(weight = fixture.weighter->EventWeight(fixture.tree));
+    EXPECT_EQ(weight, 0.0);
 }

--- a/projects/injection/private/test/Weighter_TEST.cxx
+++ b/projects/injection/private/test/Weighter_TEST.cxx
@@ -1,4 +1,5 @@
 #include <cmath>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <vector>
@@ -126,16 +127,31 @@ TEST(WeighterHelpers, LogOneMinusExpIsNegative) {
 // ---------------------------------------------------------------------------
 // Weighter::EventWeight guard behavior
 //
-// Both fixtures below use VertexWeightingMode::Fixed() on the injection and
+// The fixtures below use VertexWeightingMode::Fixed() on the injection and
 // physical process, so InteractionProbability and NormalizedPositionProbability
 // (which integrate density along the path) are never evaluated. Only the
 // channel-selection and final-state-density factors are, and both reduce to
 // an exact 1.0 for this single-channel DummyCrossSection with a matching
 // signature, so the per-vertex generation/physical probabilities are
-// predictable and the two guard branches can be pinned exactly.
+// predictable. A test position distribution supplies a controlled density.
 // ---------------------------------------------------------------------------
 
 namespace {
+
+class GuardPositionDistribution : public siren::distributions::SphereVolumePositionDistribution {
+    double density;
+public:
+    explicit GuardPositionDistribution(double density)
+        : SphereVolumePositionDistribution(siren::geometry::Sphere(50.0, 0.0)),
+          density(density) {}
+
+    double GenerationProbability(
+            std::shared_ptr<siren::detector::DetectorModel const>,
+            std::shared_ptr<siren::interactions::InteractionCollection const>,
+            siren::dataclasses::InteractionRecord const &) const override {
+        return density;
+    }
+};
 
 struct WeighterGuardFixture {
     std::shared_ptr<siren::injection::Injector> injector;
@@ -145,12 +161,11 @@ struct WeighterGuardFixture {
 
 // `events_to_inject` seeds the realized-count normalization: Weighter reads
 // EventsToInject() while InjectedEvents() is still 0 (i.e. before any
-// generation). `zero_physical_normalization` adds a NormalizationConstant(0.0)
-// to the physical process; PhysicalProbability multiplies its result by that
-// distribution's normalization, so it becomes exactly 0.0 without perturbing
-// GenerationProbability, which never applies the physical normalization.
+// generation). Physical normalization and generation density are independent,
+// so invalid inputs and arithmetic overflow can be tested separately.
 WeighterGuardFixture BuildWeighterGuardFixture(unsigned int events_to_inject,
-                                                bool zero_physical_normalization) {
+                                                double physical_normalization = 1.0,
+                                                double generation_density = 1.0) {
     siren::dataclasses::ParticleType primary_type = siren::dataclasses::ParticleType::NuMu;
     siren::dataclasses::ParticleType target_type = siren::dataclasses::ParticleType::Nucleon;
 
@@ -175,16 +190,13 @@ WeighterGuardFixture BuildWeighterGuardFixture(unsigned int events_to_inject,
         std::make_shared<siren::injection::PrimaryInjectionProcess>(primary_type, int_col);
     primary_inj->SetWeightingMode(siren::dataclasses::VertexWeightingMode::Fixed());
     primary_inj->AddPrimaryInjectionDistribution(
-        std::make_shared<siren::distributions::SphereVolumePositionDistribution>(
-            siren::geometry::Sphere(50.0, 0.0)));
+        std::make_shared<GuardPositionDistribution>(generation_density));
 
     std::shared_ptr<siren::injection::PhysicalProcess> primary_phys =
         std::make_shared<siren::injection::PhysicalProcess>(primary_type, int_col);
     primary_phys->SetWeightingMode(siren::dataclasses::VertexWeightingMode::Fixed());
-    if (zero_physical_normalization) {
-        primary_phys->AddPhysicalDistribution(
-            std::make_shared<siren::distributions::NormalizationConstant>(0.0));
-    }
+    primary_phys->AddPhysicalDistribution(
+        std::make_shared<siren::distributions::NormalizationConstant>(physical_normalization));
 
     std::shared_ptr<siren::utilities::SIREN_random> random =
         std::make_shared<siren::utilities::SIREN_random>(1234);
@@ -221,7 +233,7 @@ WeighterGuardFixture BuildWeighterGuardFixture(unsigned int events_to_inject,
 // than let the reciprocal in EventWeight blow up silently.
 TEST(WeighterGuards, GenerationProbabilityNonpositiveThrowsWeightCalculationError) {
     WeighterGuardFixture fixture = BuildWeighterGuardFixture(
-        /*events_to_inject=*/0, /*zero_physical_normalization=*/false);
+        /*events_to_inject=*/0);
     EXPECT_EQ(fixture.injector->InjectedEvents(), 0u);
     EXPECT_EQ(fixture.injector->EventsToInject(), 0u);
     EXPECT_THROW(fixture.weighter->EventWeight(fixture.tree),
@@ -233,8 +245,109 @@ TEST(WeighterGuards, GenerationProbabilityNonpositiveThrowsWeightCalculationErro
 // distinct from the generation-side guard above.
 TEST(WeighterGuards, PhysicalProbabilityZeroGivesZeroWeightWithoutThrowing) {
     WeighterGuardFixture fixture = BuildWeighterGuardFixture(
-        /*events_to_inject=*/100, /*zero_physical_normalization=*/true);
+        /*events_to_inject=*/100, /*physical_normalization=*/0.0);
     double weight = 0.0;
     EXPECT_NO_THROW(weight = fixture.weighter->EventWeight(fixture.tree));
     EXPECT_EQ(weight, 0.0);
+}
+
+TEST(WeighterGuards, InvalidPhysicalProbabilityThrows) {
+    for(double probability : {-1.0, std::numeric_limits<double>::infinity(),
+                              -std::numeric_limits<double>::infinity(),
+                              std::numeric_limits<double>::quiet_NaN()}) {
+        SCOPED_TRACE(probability);
+        auto fixture = BuildWeighterGuardFixture(1, probability);
+        EXPECT_THROW(fixture.weighter->EventWeight(fixture.tree),
+                     siren::utilities::WeightCalculationError);
+    }
+}
+
+TEST(WeighterGuards, InvalidGenerationProbabilityThrowsEvenWithZeroPhysicalProbability) {
+    for(double probability : {0.0, -1.0, std::numeric_limits<double>::infinity(),
+                              -std::numeric_limits<double>::infinity(),
+                              std::numeric_limits<double>::quiet_NaN()}) {
+        SCOPED_TRACE(probability);
+        for(double physical : {0.0, 1.0}) {
+            auto fixture = BuildWeighterGuardFixture(1, physical, probability);
+            EXPECT_THROW(fixture.weighter->EventWeight(fixture.tree),
+                         siren::utilities::WeightCalculationError);
+        }
+    }
+}
+
+TEST(WeighterGuards, FinitePositiveProbabilitiesGiveExpectedWeight) {
+    auto fixture = BuildWeighterGuardFixture(100, 2.0, 0.25);
+    EXPECT_DOUBLE_EQ(fixture.weighter->EventWeight(fixture.tree), 2.0 / 25.0);
+}
+
+TEST(WeighterGuards, InverseWeightOverflowThrowsInsteadOfReturningZero) {
+    auto fixture = BuildWeighterGuardFixture(1, 1e-308, 1e100);
+    EXPECT_THROW(fixture.weighter->EventWeight(fixture.tree),
+                 siren::utilities::WeightCalculationError);
+}
+
+TEST(WeighterGuards, WeightOverflowThrows) {
+    // The first ratio remains representable; the second underflows to zero.
+    for(double generation : {1.0, 1e-100}) {
+        auto fixture = BuildWeighterGuardFixture(1, 1e308, generation * 0.01);
+        EXPECT_THROW(fixture.weighter->EventWeight(fixture.tree),
+                     siren::utilities::WeightCalculationError);
+    }
+}
+
+TEST(WeighterGuards, PooledInverseWeightOverflowThrows) {
+    auto first = BuildWeighterGuardFixture(1, 1.0, 1e308);
+    auto second = BuildWeighterGuardFixture(1, 1.0, 1e308);
+    EXPECT_GT(first.weighter->EventWeight(first.tree), 0.0);
+    Weighter pooled({first.injector, second.injector},
+                    first.weighter->GetDetectorModel(),
+                    first.weighter->GetPrimaryPhysicalProcess());
+    EXPECT_THROW(pooled.EventWeight(first.tree),
+                 siren::utilities::WeightCalculationError);
+}
+
+TEST(WeighterGuards, ZeroPhysicalProbabilityDoesNotHideInvalidPooledInjector) {
+    auto first = BuildWeighterGuardFixture(1, 0.0);
+    auto second = BuildWeighterGuardFixture(0, 0.0);
+    Weighter pooled({first.injector, second.injector},
+                    first.weighter->GetDetectorModel(),
+                    first.weighter->GetPrimaryPhysicalProcess());
+    EXPECT_THROW(pooled.EventWeight(first.tree),
+                 siren::utilities::WeightCalculationError);
+}
+
+TEST(WeighterGuards, EmptyInjectorPoolThrowsInsteadOfReturningInfinity) {
+    auto fixture = BuildWeighterGuardFixture(1);
+    Weighter empty({}, fixture.weighter->GetDetectorModel(),
+                   fixture.weighter->GetPrimaryPhysicalProcess());
+    EXPECT_THROW(empty.EventWeight(fixture.tree),
+                 siren::utilities::WeightCalculationError);
+}
+
+TEST(WeighterGuards, ProcessWeightRejectsInvalidProbabilitiesAndOverflow) {
+    for(auto const & probabilities : std::vector<std::pair<double, double>>{
+            {-1.0, 1.0}, {1.0, -1.0}, {0.0, 0.0}, {1.0, 0.0},
+            {std::numeric_limits<double>::infinity(), 1.0},
+            {1.0, std::numeric_limits<double>::quiet_NaN()}, {1e308, 0.01}}) {
+        auto fixture = BuildWeighterGuardFixture(1, probabilities.first, probabilities.second);
+        PrimaryProcessWeighter process(fixture.weighter->GetPrimaryPhysicalProcess(),
+                                       fixture.injector->GetPrimaryProcess(),
+                                       fixture.weighter->GetDetectorModel());
+        auto const & datum = *fixture.tree.tree.front();
+        auto bounds = fixture.injector->PrimaryInjectionBounds(datum.record);
+        EXPECT_THROW(process.EventWeight(bounds, datum),
+                     siren::utilities::WeightCalculationError);
+    }
+}
+
+TEST(WeighterGuards, ProcessWeightPreservesZeroAndPositiveWeights) {
+    for(double physical : {0.0, 2.0}) {
+        auto fixture = BuildWeighterGuardFixture(1, physical, 0.25);
+        PrimaryProcessWeighter process(fixture.weighter->GetPrimaryPhysicalProcess(),
+                                       fixture.injector->GetPrimaryProcess(),
+                                       fixture.weighter->GetDetectorModel());
+        auto const & datum = *fixture.tree.tree.front();
+        auto bounds = fixture.injector->PrimaryInjectionBounds(datum.record);
+        EXPECT_DOUBLE_EQ(process.EventWeight(bounds, datum), physical / 0.25);
+    }
 }

--- a/projects/injection/public/SIREN/injection/Injector.h
+++ b/projects/injection/public/SIREN/injection/Injector.h
@@ -141,6 +141,7 @@ public:
     std::string GetLastFailureReason() const;
     siren::dataclasses::InteractionTree const & GetLastFailedTree() const;
     void ResetInjectedEvents(unsigned int events_to_inject);
+    void ResetInjectedEvents();
 
     // --- Channel-weight optimizer support (feed the mixtures' KP accumulators) ---
 
@@ -169,28 +170,41 @@ public:
 
     template<typename Archive>
     void save(Archive & archive, std::uint32_t const version) const {
-        if(version == 0) {
+        if(version <= 1) {
             archive(::cereal::make_nvp("EventsToInject", events_to_inject));
             archive(::cereal::make_nvp("InjectionAttempts", injection_attempts));
             archive(::cereal::make_nvp("InjectedEvents", injected_events));
+            // FailedEvents added in version 1 so attempts ~= injected + failed
+            // survives a save/load round-trip. cereal passes the current class
+            // version (>= 1) on save, so it is always written here.
+            if(version >= 1) {
+                archive(::cereal::make_nvp("FailedEvents", failed_events));
+            }
             archive(::cereal::make_nvp("DetectorModel", detector_model));
             // archive(::cereal::make_nvp("SIRENRandom", random));
             archive(::cereal::make_nvp("PrimaryProcess", primary_process));
             archive(::cereal::make_nvp("SecondaryProcesses", secondary_processes));
         } else {
-            throw std::runtime_error("Injector only supports version <= 0!");
+            throw std::runtime_error("Injector only supports version <= 1!");
         }
     }
 
+    // Rebuilds processes via SetPrimaryProcess/AddSecondaryProcess, so a corrupt or
+    // incompatible archive throws siren::utilities::AddProcessFailure instead of exiting.
     template<typename Archive>
     void load(Archive & archive, std::uint32_t const version) {
-        if(version == 0) {
+        if(version <= 1) {
             std::shared_ptr<injection::PrimaryInjectionProcess> _primary_process;
             std::vector<std::shared_ptr<injection::SecondaryInjectionProcess>> _secondary_processes;
 
             archive(::cereal::make_nvp("EventsToInject", events_to_inject));
             archive(::cereal::make_nvp("InjectionAttempts", injection_attempts));
             archive(::cereal::make_nvp("InjectedEvents", injected_events));
+            // FailedEvents added in version 1. Version-0 archives omit it, so
+            // failed_events keeps its default (0) for backward compatibility.
+            if(version >= 1) {
+                archive(::cereal::make_nvp("FailedEvents", failed_events));
+            }
             archive(::cereal::make_nvp("DetectorModel", detector_model));
             // archive(::cereal::make_nvp("SIRENRandom", random));
             archive(::cereal::make_nvp("PrimaryProcess", _primary_process));
@@ -200,7 +214,7 @@ public:
                 AddSecondaryProcess(secondary_process);
             }
         } else {
-            throw std::runtime_error("Injector only supports version <= 0!");
+            throw std::runtime_error("Injector only supports version <= 1!");
         }
     }
 };
@@ -208,6 +222,6 @@ public:
 } // namespace injection
 } // namespace siren
 
-CEREAL_CLASS_VERSION(siren::injection::Injector, 0);
+CEREAL_CLASS_VERSION(siren::injection::Injector, 1);
 
 #endif // SIREN_Injector_H

--- a/projects/injection/public/SIREN/injection/Weighter.tcc
+++ b/projects/injection/public/SIREN/injection/Weighter.tcc
@@ -11,6 +11,7 @@
 #include <iostream>                                               // for ope...
 #include <set>                                                    // for set
 #include <stdexcept>                                              // for out...
+#include <sstream>
 
 #include <type_traits>
 
@@ -28,6 +29,7 @@
 #include "SIREN/injection/Process.h"                     // for Phy...
 #include "SIREN/injection/WeightingUtils.h"              // for Cro...
 #include "SIREN/math/Vector3D.h"                         // for Vec...
+#include "SIREN/utilities/Errors.h"
 
 #include <tuple>
 #include <cassert>
@@ -350,8 +352,27 @@ template<typename ProcessType>
 double ProcessWeighter<ProcessType>::EventWeight(std::tuple<siren::math::Vector3D, siren::math::Vector3D> const & bounds,
         siren::dataclasses::InteractionTreeDatum const & datum) const {
     PhaseSpaceConvention convention = WeightingConvention(datum.record);
-    return PhysicalProbability(bounds, datum.record, convention)
-         / GenerationProbability(datum, convention);
+    double physical = PhysicalProbability(bounds, datum.record, convention);
+    double generation = GenerationProbability(datum, convention);
+    if(generation <= 0.0 || !std::isfinite(generation)
+       || physical < 0.0 || !std::isfinite(physical)) {
+        std::ostringstream oss;
+        oss << "ProcessWeighter::EventWeight: unusable probabilities for primary type "
+            << datum.record.signature.primary_type
+            << ": generation_probability=" << generation
+            << ", physical_probability=" << physical
+            << " [siren-docs: errors#weight-calc]";
+        throw siren::utilities::WeightCalculationError(oss.str());
+    }
+    double weight = physical / generation;
+    if(!std::isfinite(weight) || weight < 0.0) {
+        std::ostringstream oss;
+        oss << "ProcessWeighter::EventWeight: unusable event weight=" << weight
+            << " for primary type " << datum.record.signature.primary_type
+            << " [siren-docs: errors#weight-calc]";
+        throw siren::utilities::WeightCalculationError(oss.str());
+    }
+    return weight;
 }
 
 template<typename ProcessType>

--- a/tests/python/test_golden_regression.py
+++ b/tests/python/test_golden_regression.py
@@ -111,12 +111,25 @@ _M_V1 = 0.017
 # Part 1: a real assembled injector + weighter (multi-vertex, data-free)       #
 # --------------------------------------------------------------------------- #
 
-def _load_ccm_detector():
-    """Load the CCM detector model, or skip if its data files are missing.
+def _skip_unless_ccm_data():
+    """Skip only when the CCM detector data files are absent.
 
-    Only a missing-data condition (ValueError from path resolution, RuntimeError
-    from a failed file open) is a skip; anything else is a real regression.
+    Missing files are an environment condition; any error raised while
+    PARSING present files is a real regression and must propagate.
     """
+    try:
+        det_dir = _util.get_detector_model_path("CCM")
+    except ValueError as e:
+        pytest.skip(f"CCM detector model path unavailable: {e}")
+    missing = [p for p in (os.path.join(det_dir, "materials.dat"),
+                           os.path.join(det_dir, "densities.dat"))
+               if not os.path.exists(p)]
+    if missing:
+        pytest.skip("CCM detector data missing: " + ", ".join(missing))
+
+
+def _load_ccm_detector():
+    """Load the CCM detector model; errors propagate to the caller."""
     dm = detector.DetectorModel()
     det_dir = _util.get_detector_model_path("CCM")
     dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
@@ -202,10 +215,11 @@ def _generate_chain_arrays(detector_model):
             break
         try:
             ev = inj.GenerateEvent()
-        except RuntimeError:
-            # The only RuntimeError GenerateEvent() raises is the max-attempts
-            # sentinel; InjectionFailure surfaces as an empty tree, so this
-            # cannot mask another failure.
+        except RuntimeError as err:
+            # Only the max-attempts sentinel ends the loop; any other typed
+            # engine RuntimeError re-raises so it cannot be masked here.
+            if "maximum number of injection attempts" not in str(err):
+                raise
             break
         if len(ev.tree) == 0:
             continue
@@ -341,10 +355,8 @@ def _load_archive():
 def test_golden_weighted_distributions():
     """Fixed-seed assembled chain reproduces the archived weighted distributions
     to rtol=1e-12."""
-    try:
-        detector_model = _load_ccm_detector()
-    except (ValueError, RuntimeError) as e:
-        pytest.skip(f"CCM detector model unavailable: {e}")
+    _skip_unless_ccm_data()
+    detector_model = _load_ccm_detector()
 
     archive = _load_archive()
     fresh = _generate_chain_arrays(detector_model)

--- a/tests/python/test_golden_regression.py
+++ b/tests/python/test_golden_regression.py
@@ -29,7 +29,14 @@ new "golden" from whatever the current (possibly broken) code produces.
 
 What is pinned
 --------------
-1. test_golden_kp_alphas -- a fixed-seed Kleiss-Pittau optimization of a toy
+1. test_golden_weighted_distributions -- a fixed-seed multi-vertex chain built
+   from a real siren injection.Injector + injection.Weighter (the same
+   data-free DummyCrossSection + CCM-detector assembly used by the HepMC3
+   closure tests). N=500 accepted events. Archived: the per-event weights, the
+   primary energies, the interaction-vertex coordinates, the per-event tree
+   depth (a cheap kinematic-topology observable available from the chain), and
+   weighted histograms of energy and of vertex radius.
+2. test_golden_kp_alphas -- a fixed-seed Kleiss-Pittau optimization of a toy
    3-channel mixture (physical/isotropic + two detector-directed channels) via
    tune.optimize_multichannel_weights, which drives the bare
    W_i = mean(w^2 g_i/g) statistic through the C++ Accumulate/UpdateWeights
@@ -101,6 +108,151 @@ _M_V1 = 0.017
 
 
 # --------------------------------------------------------------------------- #
+# Part 1: a real assembled injector + weighter (multi-vertex, data-free)       #
+# --------------------------------------------------------------------------- #
+
+def _load_ccm_detector():
+    """Load the CCM detector model, or skip if its data files are missing.
+
+    Only a missing-data condition (ValueError from path resolution, RuntimeError
+    from a failed file open) is a skip; anything else is a real regression.
+    """
+    dm = detector.DetectorModel()
+    det_dir = _util.get_detector_model_path("CCM")
+    dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+    dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    return dm
+
+
+def _build_chain(detector_model, n_inject, seed):
+    """Assemble a real multi-vertex Injector + Weighter over a data-free
+    DummyCrossSection.
+
+    Generation flux: a power-law energy spectrum, a neutrino-helicity
+    distribution, isotropic direction, and a point-source position -- so the
+    weight genuinely depends on energy, helicity, and geometry (a monoenergetic
+    setup would not exercise the reweighting). One generation of secondaries is
+    simulated so every event is a multi-vertex cascade. Returns
+    (injector, weighter, keepalive) where keepalive holds Python objects that
+    must outlive the C++ engines.
+    """
+    xs = interactions.DummyCrossSection()
+    int_col = interactions.InteractionCollection(_NuMu, [xs])
+
+    primary_inj = injection.PrimaryInjectionProcess()
+    primary_inj.primary_type = _NuMu
+    primary_inj.interactions = int_col
+    primary_inj.distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+
+    primary_phys = injection.PhysicalProcess()
+    primary_phys.primary_type = _NuMu
+    primary_phys.interactions = int_col
+    primary_phys.distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+    ]
+
+    sec_xs = interactions.DummyCrossSection()
+    sec_col = interactions.InteractionCollection(_NuMu, [sec_xs])
+
+    sec_inj = injection.SecondaryInjectionProcess()
+    sec_inj.primary_type = _NuMu
+    sec_inj.interactions = sec_col
+    sec_inj.distributions = [distributions.SecondaryPhysicalVertexDistribution()]
+
+    sec_phys = injection.PhysicalProcess()
+    sec_phys.primary_type = _NuMu
+    sec_phys.interactions = sec_col
+    sec_phys.distributions = [distributions.SecondaryPhysicalVertexDistribution()]
+
+    rand = utilities.SIREN_random(seed)
+    inj = injection._Injector(n_inject, detector_model, primary_inj, [sec_inj], rand)
+    # Simulate exactly one generation of secondaries (stop at depth >= 1).
+    inj.SetStoppingCondition(lambda tree, datum, i: datum.depth(tree) >= 1)
+    weighter = injection._Weighter([inj], detector_model, primary_phys, [sec_phys])
+
+    keepalive = (xs, int_col, sec_xs, sec_col, primary_inj, primary_phys,
+                 sec_inj, sec_phys, rand)
+    return inj, weighter, keepalive
+
+
+def _generate_chain_arrays(detector_model):
+    """Generate N_EVENTS accepted events and return the pinned per-event arrays
+    plus the derived weighted histograms.
+
+    Deterministic: identical seeds -> identical arrays (verified by the second
+    pytest run in CI and by the determinism assertions here).
+    """
+    inj, weighter, _keepalive = _build_chain(detector_model, MAX_ATTEMPTS, CHAIN_SEED)
+
+    events = []
+    energy = []
+    vx, vy, vz = [], [], []
+    depth = []
+
+    for _ in range(MAX_ATTEMPTS):
+        if len(events) >= N_EVENTS:
+            break
+        try:
+            ev = inj.GenerateEvent()
+        except RuntimeError:
+            # The only RuntimeError GenerateEvent() raises is the max-attempts
+            # sentinel; InjectionFailure surfaces as an empty tree, so this
+            # cannot mask another failure.
+            break
+        if len(ev.tree) == 0:
+            continue
+        root = ev.tree[0].record
+        p = root.primary_momentum
+        v = root.interaction_vertex
+        events.append(ev)
+        energy.append(p[0])
+        vx.append(v[0])
+        vy.append(v[1])
+        vz.append(v[2])
+        depth.append(len(ev.tree))
+
+    if len(events) < N_EVENTS:
+        raise RuntimeError(
+            f"golden chain produced only {len(events)} accepted events "
+            f"(< N_EVENTS={N_EVENTS}) within {MAX_ATTEMPTS} attempts")
+
+    # Weight after generation completes: EventWeight normalizes by the realized
+    # injected count, so all events must share the same (final) normalization.
+    # Weighting mid-generation would bake the running count into each weight.
+    weights = [weighter.EventWeight(ev) for ev in events]
+
+    weights = np.asarray(weights[:N_EVENTS], dtype=np.float64)
+    energy = np.asarray(energy[:N_EVENTS], dtype=np.float64)
+    vx = np.asarray(vx[:N_EVENTS], dtype=np.float64)
+    vy = np.asarray(vy[:N_EVENTS], dtype=np.float64)
+    vz = np.asarray(vz[:N_EVENTS], dtype=np.float64)
+    depth = np.asarray(depth[:N_EVENTS], dtype=np.float64)
+
+    radius = np.sqrt(vx * vx + vy * vy + vz * vz)
+    energy_hist, _ = np.histogram(energy, bins=E_BINS, weights=weights)
+    radius_hist, _ = np.histogram(radius, bins=R_BINS, weights=weights)
+
+    return {
+        "chain_weights": weights,
+        "chain_energy": energy,
+        "chain_vx": vx,
+        "chain_vy": vy,
+        "chain_vz": vz,
+        "chain_depth": depth,
+        "chain_energy_hist": energy_hist.astype(np.float64),
+        "chain_radius_hist": radius_hist.astype(np.float64),
+    }
+
+
+# --------------------------------------------------------------------------- #
 # Part 2: Kleiss-Pittau optimizer toy (pins the bare W_i statistic)            #
 # --------------------------------------------------------------------------- #
 
@@ -166,6 +318,15 @@ def _generate_kp_alphas():
 # Archive helpers                                                             #
 # --------------------------------------------------------------------------- #
 
+def _build_archive():
+    """Compute every pinned array. Used both by --regenerate and by the tests."""
+    detector_model = _load_ccm_detector()
+    data = {}
+    data.update(_generate_chain_arrays(detector_model))
+    data.update(_generate_kp_alphas())
+    return data
+
+
 def _load_archive():
     if not ARCHIVE.exists():
         pytest.fail(_REGEN_MSG.format(path=ARCHIVE))
@@ -176,6 +337,34 @@ def _load_archive():
 # --------------------------------------------------------------------------- #
 # Tests                                                                       #
 # --------------------------------------------------------------------------- #
+
+def test_golden_weighted_distributions():
+    """Fixed-seed assembled chain reproduces the archived weighted distributions
+    to rtol=1e-12."""
+    try:
+        detector_model = _load_ccm_detector()
+    except (ValueError, RuntimeError) as e:
+        pytest.skip(f"CCM detector model unavailable: {e}")
+
+    archive = _load_archive()
+    fresh = _generate_chain_arrays(detector_model)
+
+    for key in ("chain_weights", "chain_energy", "chain_vx", "chain_vy",
+                "chain_vz", "chain_depth", "chain_energy_hist",
+                "chain_radius_hist"):
+        assert key in archive, f"archive missing key {key!r}; regenerate it"
+        np.testing.assert_allclose(
+            fresh[key], archive[key], rtol=RTOL, atol=ATOL,
+            err_msg=(f"golden chain array {key!r} changed. If this is an "
+                     "intended, changelog-labeled physics change, regenerate "
+                     "the archive; otherwise the engine numerics moved."))
+
+    # Sanity: the pinned sample really is the assembled multi-vertex pipeline.
+    assert fresh["chain_weights"].shape == (N_EVENTS,)
+    assert np.all(np.isfinite(fresh["chain_weights"]))
+    assert np.all(fresh["chain_weights"] > 0.0)
+    assert np.all(fresh["chain_depth"] >= 2.0)   # secondaries -> multi-vertex
+
 
 def test_golden_kp_alphas():
     """Fixed-seed Kleiss-Pittau optimizer reproduces the archived converged
@@ -195,3 +384,34 @@ def test_golden_kp_alphas():
     assert alphas.shape == (3,)
     assert abs(float(alphas.sum()) - 1.0) < 1e-9
     assert np.all(alphas >= 0.0)
+
+
+# --------------------------------------------------------------------------- #
+# Regeneration entry point (never invoked by pytest)                          #
+# --------------------------------------------------------------------------- #
+
+def _regenerate():
+    data = _build_archive()
+    ARCHIVE.parent.mkdir(parents=True, exist_ok=True)
+    np.savez(ARCHIVE, **data)
+    print(f"wrote {ARCHIVE}")
+    for key in sorted(data):
+        arr = np.asarray(data[key])
+        print(f"  {key}: shape={arr.shape} dtype={arr.dtype}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Regenerate the golden-physics regression archive. "
+                    "Only run this as part of a deliberate, changelog-labeled "
+                    "physics change.")
+    parser.add_argument("--regenerate", action="store_true",
+                        help="recompute and overwrite the archive .npz")
+    args = parser.parse_args()
+
+    if args.regenerate:
+        _regenerate()
+    else:
+        parser.error("pass --regenerate to write the archive")

--- a/tests/python/test_injector_serialization.py
+++ b/tests/python/test_injector_serialization.py
@@ -1,10 +1,16 @@
-"""Fixed-vertex channel-factor pins.
+"""Injector serialization and Fixed-vertex channel-factor pins.
 
-Data-free and fixed-seed throughout: FixedVertexChannelSelectionProbability
-returns exactly 1.0 for a single-channel process (an exact float no-op) and
-selected_rate/total_rate when multiple channels compete, so a Fixed vertex
-charges the same channel-selection factor the injector's rate selection
-applied.
+Data-free and fixed-seed throughout:
+
+  (a) The raw C++ injector (siren.injection._Injector) round-trips
+      InjectionAttempts, InjectedEvents, FailedEvents, and each process's
+      weighting mode across SaveInjector/LoadInjector.
+
+  (b) FixedVertexChannelSelectionProbability returns exactly 1.0 for a
+      single-channel process (an exact float no-op) and
+      selected_rate/total_rate when multiple channels compete, so a Fixed
+      vertex charges the same channel-selection factor the injector's rate
+      selection applied.
 """
 
 import math
@@ -15,8 +21,92 @@ import siren
 from siren import dataclasses as dc
 from siren import injection
 from siren import interactions
+from siren import distributions
+from siren import math as smath
+from siren import utilities
 
 _NuMu = dc.Particle.ParticleType.NuMu
+
+
+def _distributions(max_distance):
+    return [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(
+            smath.Vector3D(0, 0, 0), max_distance),
+    ]
+
+
+def _raw_forced_failure_injector(events, seed, weighting_mode):
+    """A raw _Injector whose every attempt fails (bare detector, zero source
+    distance means every path misses its target), with a Fixed-mode primary
+    process. No detector data files are needed."""
+    dm = siren.detector.DetectorModel()
+    collection = interactions.InteractionCollection(
+        _NuMu, [interactions.DummyCrossSection()])
+    primary = injection.PrimaryInjectionProcess(_NuMu, collection)
+    primary.distributions = _distributions(0.0)
+    primary.weighting_mode = weighting_mode
+    random = utilities.SIREN_random(seed)
+    return injection._Injector(events, dm, primary, random)
+
+
+# ------------------------------------------------------------------ #
+#  (a) SaveInjector/LoadInjector round-trip                           #
+# ------------------------------------------------------------------ #
+
+def test_save_load_preserves_counters_and_weighting_mode(tmp_path):
+    """Counters and the primary process's weighting mode survive a raw
+    SaveInjector/LoadInjector round-trip."""
+    events = 6
+    fixed = injection.VertexWeightingMode.Fixed()
+    inj = _raw_forced_failure_injector(events=events, seed=13, weighting_mode=fixed)
+
+    # Every attempt fails; GenerateEvent catches the failure internally and
+    # returns an empty tree, so drive it up to the configured attempt cap.
+    for _ in range(events):
+        tree = inj.GenerateEvent()
+        assert len(tree.tree) == 0
+
+    assert inj.InjectionAttempts() == events
+    assert inj.InjectedEvents() == 0
+    assert inj.FailedEvents() == events
+    # The accounting invariant that motivated serializing FailedEvents.
+    assert inj.InjectionAttempts() == inj.InjectedEvents() + inj.FailedEvents()
+
+    path = str(tmp_path / "injector_roundtrip")
+    inj.SaveInjector(path)
+
+    reloaded = injection._Injector.__new__(injection._Injector)
+    reloaded.LoadInjector(path)
+
+    assert reloaded.InjectionAttempts() == inj.InjectionAttempts()
+    assert reloaded.InjectedEvents() == inj.InjectedEvents()
+    assert reloaded.FailedEvents() == inj.FailedEvents()
+    assert reloaded.InjectionAttempts() == (
+        reloaded.InjectedEvents() + reloaded.FailedEvents())
+
+    # The archive round-trip preserves the Fixed weighting mode.
+    assert reloaded.GetPrimaryProcess().GetWeightingMode() == fixed
+    assert reloaded.GetPrimaryProcess().GetWeightingMode() != (
+        injection.VertexWeightingMode.Propagated())
+
+
+def test_failed_events_default_when_not_yet_generated(tmp_path):
+    """A freshly-built injector round-trips with all counters at zero."""
+    inj = _raw_forced_failure_injector(
+        events=3, seed=1, weighting_mode=injection.VertexWeightingMode.Propagated())
+    path = str(tmp_path / "injector_fresh")
+    inj.SaveInjector(path)
+    reloaded = injection._Injector.__new__(injection._Injector)
+    reloaded.LoadInjector(path)
+    assert reloaded.InjectionAttempts() == 0
+    assert reloaded.InjectedEvents() == 0
+    assert reloaded.FailedEvents() == 0
+    assert reloaded.GetPrimaryProcess().GetWeightingMode() == (
+        injection.VertexWeightingMode.Propagated())
 
 
 # ------------------------------------------------------------------ #

--- a/tests/python/test_weighter_guards.py
+++ b/tests/python/test_weighter_guards.py
@@ -1,0 +1,190 @@
+"""Weighter fail-loud + realized-count normalization behavior.
+
+This uses the same data-free chain the golden-regression and HepMC3 closure
+tests use: a DummyCrossSection over the (checked-in) CCM detector model, a
+PowerLaw energy spectrum, and a point-source vertex -- so a genuine
+injection + weighting round-trip runs without external tables.
+
+Pinned:
+  * the event weight normalizes by the REALIZED injected count
+    (InjectedEvents()), not the requested count. Weighting the same event at two
+    different realized counts M and N scales as w_M * M == w_N * N.
+
+Two further guard behaviors are pinned in C++ (Weighter_TEST.cxx) rather than
+here, since they are not cheaply constructible from a pure-Python injection
+chain:
+  * generation_probability <= 0 -> WeightCalculationError
+  * physical_probability == 0 -> weight exactly 0.0 (no raise)
+
+ASCII only. No network. Each test stays well under ~30s.
+"""
+import math
+import os
+
+import pytest
+
+siren = pytest.importorskip("siren")
+
+from siren import injection
+from siren import interactions
+from siren import distributions
+from siren import detector
+from siren import math as smath
+from siren import utilities
+from siren import _util
+
+
+_NuMu = siren.dataclasses.Particle.ParticleType.NuMu
+
+
+# ------------------------------------------------------------------ #
+#  Data-free single-vertex chain over the CCM detector                #
+# ------------------------------------------------------------------ #
+
+def _load_ccm_detector():
+    """Load the CCM detector model or skip if its data files are missing."""
+    try:
+        det_dir = _util.get_detector_model_path("CCM")
+        materials = os.path.join(det_dir, "materials.dat")
+        densities = os.path.join(det_dir, "densities.dat")
+        if not (os.path.exists(materials) and os.path.exists(densities)):
+            pytest.skip("CCM detector data files not present")
+        dm = detector.DetectorModel()
+        dm.LoadMaterialModel(materials)
+        dm.LoadDetectorModel(densities)
+        return dm
+    except (ValueError, RuntimeError) as exc:
+        pytest.skip("CCM detector model unavailable: {}".format(exc))
+
+
+def _build_chain(detector_model, n_inject, seed):
+    """A single-vertex Injector + Weighter over a DummyCrossSection.
+
+    The generation flux is a genuine PowerLaw energy spectrum (so the weight
+    depends on energy), plus helicity/direction/vertex distributions. Returns
+    (injector, weighter, keepalive) -- keepalive holds Python objects that must
+    outlive the C++ engines.
+    """
+    xs = interactions.DummyCrossSection()
+    int_col = interactions.InteractionCollection(_NuMu, [xs])
+
+    primary_inj = injection.PrimaryInjectionProcess()
+    primary_inj.primary_type = _NuMu
+    primary_inj.interactions = int_col
+    primary_inj.distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+
+    primary_phys = injection.PhysicalProcess()
+    primary_phys.primary_type = _NuMu
+    primary_phys.interactions = int_col
+    primary_phys.distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+    ]
+
+    rand = utilities.SIREN_random(seed)
+    inj = injection._Injector(n_inject, detector_model, primary_inj, [], rand)
+    weighter = injection._Weighter([inj], detector_model, primary_phys, [])
+
+    keepalive = (xs, int_col, primary_inj, primary_phys, rand)
+    return inj, weighter, keepalive
+
+
+def _generate_until(inj, target):
+    """Generate until InjectedEvents() reaches `target`; return the last
+    non-empty event (a valid tree to weight)."""
+    last = None
+    guard = 0
+    while inj.InjectedEvents() < target:
+        ev = inj.GenerateEvent()
+        guard += 1
+        if len(ev.tree) > 0:
+            last = ev
+        if guard > 20 * max(target, 1):
+            break
+    return last
+
+
+# ------------------------------------------------------------------ #
+#  weight normalizes by realized injected count                    #
+# ------------------------------------------------------------------ #
+
+def test_weight_scales_with_realized_injected_count():
+    """The same event, weighted when the injector has realized M injected events
+    vs N, must satisfy w_M * M == w_N * N (the generation seed is the realized
+    count InjectedEvents(), so w ~ 1/InjectedEvents and the count-independent
+    physical/generation-density product is w * InjectedEvents).
+    """
+    dm = _load_ccm_detector()
+    inj, weighter, _keep = _build_chain(dm, n_inject=200, seed=1234)
+
+    M = 10
+    event = _generate_until(inj, M)
+    assert event is not None and len(event.tree) > 0, "no event generated"
+    iM = inj.InjectedEvents()
+    assert iM >= M
+    w_M = weighter.EventWeight(event)
+    assert math.isfinite(w_M) and w_M > 0.0
+
+    # Generate more, then re-weight the SAME stored event at a larger realized
+    # count. EventWeight reads the injector's CURRENT InjectedEvents().
+    N = 80
+    _generate_until(inj, N)
+    iN = inj.InjectedEvents()
+    assert iN >= N and iN > iM
+    w_N = weighter.EventWeight(event)
+    assert math.isfinite(w_N) and w_N > 0.0
+
+    # Contract: w_M * M == w_N * N (both equal the realized-count-independent
+    # physical/generation-density product).
+    lhs = w_M * iM
+    rhs = w_N * iN
+    assert math.isclose(lhs, rhs, rel_tol=1e-9), (
+        "weight did not scale with realized injected count: "
+        "w_M={} (M={}), w_N={} (N={}); w_M*M={} vs w_N*N={} "
+        "(if these are equal only because w_M==w_N, the realized-count seed "
+        "was not applied)".format(w_M, iM, w_N, iN, lhs, rhs))
+
+    # Guard against count-independent normalization (that would give
+    # w_M == w_N, hence w_M*M != w_N*N for M != N).
+    assert not math.isclose(w_M, w_N, rel_tol=1e-9), (
+        "weight is independent of realized count (w_M == w_N); the "
+        "realized-count normalization (InjectedEvents seeding) is not active")
+
+
+def test_weight_falls_back_to_events_to_inject_before_generation():
+    """Before any generation InjectedEvents()==0, so the weight seed falls back
+    to EventsToInject(); after generation it uses the realized count. The two
+    weights of the same event differ by exactly the count ratio.
+    """
+    dm = _load_ccm_detector()
+    inj, weighter, _keep = _build_chain(dm, n_inject=100, seed=99)
+
+    # Generate a handful, keep one event.
+    M = 7
+    event = _generate_until(inj, M)
+    assert event is not None and len(event.tree) > 0
+    realized = inj.InjectedEvents()
+    w_realized = weighter.EventWeight(event)
+
+    # Reset the run counters (zero-arg reset preserves the quota) so
+    # InjectedEvents()==0 and the seed falls back to EventsToInject().
+    inj.ResetInjectedEvents()
+    assert inj.InjectedEvents() == 0
+    quota = inj.EventsToInject()
+    assert quota == 100
+    w_fallback = weighter.EventWeight(event)
+
+    assert math.isfinite(w_realized) and w_realized > 0.0
+    assert math.isfinite(w_fallback) and w_fallback > 0.0
+    # w ~ 1/seed, so w_realized * realized == w_fallback * quota.
+    assert math.isclose(w_realized * realized, w_fallback * quota, rel_tol=1e-9), (
+        "fallback seed mismatch: w_realized*realized={} vs w_fallback*quota={}"
+        .format(w_realized * realized, w_fallback * quota))
+

--- a/tests/python/test_weighter_guards.py
+++ b/tests/python/test_weighter_guards.py
@@ -10,11 +10,9 @@ Pinned:
     (InjectedEvents()), not the requested count. Weighting the same event at two
     different realized counts M and N scales as w_M * M == w_N * N.
 
-Two further guard behaviors are pinned in C++ (Weighter_TEST.cxx) rather than
-here, since they are not cheaply constructible from a pure-Python injection
-chain:
-  * generation_probability <= 0 -> WeightCalculationError
-  * physical_probability == 0 -> weight exactly 0.0 (no raise)
+Native guard branches, zero weights, and arithmetic overflow are pinned in
+Weighter_TEST.cxx. These tests also verify that invalid physical probabilities
+propagate as the typed WeightCalculationError through the Python binding.
 
 ASCII only. No network. Each test stays well under ~30s.
 """
@@ -188,3 +186,43 @@ def test_weight_falls_back_to_events_to_inject_before_generation():
         "fallback seed mismatch: w_realized*realized={} vs w_fallback*quota={}"
         .format(w_realized * realized, w_fallback * quota))
 
+
+@pytest.mark.parametrize("normalization", [-1.0, float("inf"), -float("inf"), float("nan")])
+def test_invalid_physical_probability_raises_typed_error(normalization):
+    dm = _load_ccm_detector()
+    inj, _weighter, keepalive = _build_chain(dm, n_inject=1, seed=1234)
+    event = _generate_until(inj, 1)
+    assert event is not None
+    primary_phys = keepalive[3]
+    primary_phys.distributions = list(primary_phys.distributions) + [
+        distributions.NormalizationConstant(normalization),
+    ]
+    weighter = injection._Weighter([inj], dm, primary_phys, [])
+    with pytest.raises(utilities.WeightCalculationError, match="unusable probabilities"):
+        weighter.EventWeight(event)
+
+
+@pytest.mark.parametrize("primary_normalization", [-1.0, 0.0, 1.0])
+def test_negative_secondary_probability_cannot_cancel_or_hide(primary_normalization):
+    dm = _load_ccm_detector()
+    _inj, _weighter, keepalive = _build_chain(dm, n_inject=1, seed=5678)
+    _xs, int_col, primary_inj, primary_phys, rand = keepalive
+    secondary_inj = injection.SecondaryInjectionProcess()
+    secondary_inj.primary_type = _NuMu
+    secondary_inj.interactions = int_col
+    secondary_inj.distributions = [distributions.SecondaryPhysicalVertexDistribution()]
+    secondary_phys = injection.PhysicalProcess()
+    secondary_phys.primary_type = _NuMu
+    secondary_phys.interactions = int_col
+    secondary_phys.distributions = [distributions.SecondaryPhysicalVertexDistribution(),
+                                    distributions.NormalizationConstant(-1.0)]
+    primary_phys.distributions = list(primary_phys.distributions) + [
+        distributions.NormalizationConstant(primary_normalization),
+    ]
+    inj = injection._Injector(1, dm, primary_inj, [secondary_inj], rand)
+    inj.SetStoppingCondition(lambda tree, datum, i: datum.depth(tree) >= 1)
+    weighter = injection._Weighter([inj], dm, primary_phys, [secondary_phys])
+    event = _generate_until(inj, 1)
+    assert event is not None and len(event.tree) >= 2
+    with pytest.raises(utilities.WeightCalculationError, match="unusable probabilities"):
+        weighter.EventWeight(event)


### PR DESCRIPTION
This PR gives the legacy injection and weighting engine a fail-loud
surface and the golden regression harness. Misconfigured primary and
secondary processes let AddProcessFailure propagate to the caller
rather than terminating the interpreter, and Weighter initialization
mismatches and missing secondary process weighters raise
ConfigurationError with the injector index reported correctly. Injector
archives gain a magic-word header and a version-1 payload that
round-trips FailedEvents alongside a zero-argument ResetInjectedEvents
overload, and the serialization suite pins the round-trip of the
counters and each process's weighting mode.

Two commits change physical behavior rather than just failure
reporting: one normalizes EventWeight by the realized injected-event
count, falling back to the configured target before generation, and
adds a guard that catches a non-finite generation probability before
it can produce a NaN weight; the other makes
PrimaryExternalDistribution raise WeightCalculationError when its
cached generation probability is missing rather than silently falling
back.

The PR also carries the fixed-seed golden weighted-distributions pin: a
data-free assembled chain whose weighted distributions are pinned
against the committed archive at rtol=1e-12, regenerating only for
changelog-labeled physics changes.

At this PR's boundary: the build is green; pytest 600 passed, 25 skipped, 14 warnings; the golden archive is byte-identical to its committed form.

Supersedes #162 (`pr/fail-loud-hardening`); pre-rewrite history is
preserved at tag `archive/v1/fail-loud-hardening`.

Note: this branch's history was consolidated a second time after review
began; line-anchored review comments (from either round) may reference
superseded line numbers.

