### PR TITLE
Add the spec vocabulary modules: errors, channels, expand, vertex

### DIFF
--- a/python/_directed.py
+++ b/python/_directed.py
@@ -1,0 +1,192 @@
+"""Directed: sugar over channels.py for the common directed+fallback mix.
+
+Directed(...) describes "point this daughter at a target volume, with a
+physical() fallback so events that miss the target are not lost from the
+estimator." It never introduces a new engine primitive: every
+Directed compiles to exactly the channels.Mixture the channels algebra
+would build by hand. Directed.by_signature({signature: Directed|Mixture})
+covers the case where different signatures of the same vertex need
+different directed treatments (e.g. a 2-body and a 3-body decay channel
+of the same Decay model).
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Union
+
+from . import channels as _channels
+from .errors import ConfigurationError
+
+__all__ = ["Directed"]
+
+
+def _siren():
+    import siren
+    return siren
+
+
+def _fallback(daughter):
+    """The physical() fallback channel for a Directed mixture.
+
+    physical() late-binds a PhysicalDecayChannel/PhysicalCrossSectionChannel
+    against the vertex's own interaction model at compile time; it samples the
+    real physical distribution rather than an isotropic proxy. It is the sole
+    fallback -- a missing model is a hard configuration error:
+    Mixture.compile()/validate() raises ConfigurationError from inside
+    physical()'s factory if none is available at compile time.
+    """
+    return _channels.physical()
+
+
+class Directed:
+    """Sugar over channels.py for "directed daughter, with a fallback".
+
+    Parameters
+    ----------
+    particle : str or ParticleType
+        The daughter this Directed points at `toward`. Named, not
+        indexed, so the same Directed can be reused across signatures
+        where the daughter's position among secondaries differs.
+    toward : Geometry
+        The target volume passed to the underlying toward()/
+        toward_3body()/scatter_toward() factory.
+    fraction : float, optional
+        Weight given to the directed term; `1 - fraction` goes to the
+        fallback (physical() by default). Defaults to 0.98. Callers
+        wanting Simulation's 0.99/0.01 split pass fraction=0.99 explicitly
+        -- this class never hardcodes that value.
+    mode : optional
+        DirectedMode passed through to the channel factory. Defaults to
+        DirectedMode.Volume (channels.py's own default).
+    spectator : str or ParticleType, optional
+        Selects toward_3body()'s recursive strategy: the spectator
+        daughter of a 3-body directed channel.
+    pair_mass : channels.PairMass, optional
+        Invariant-mass sampling law for a 3-body directed channel's pair.
+    variable : optional
+        ScatteringVariable selecting scatter_toward()'s sampled variable;
+        its presence (along with q2_mode) is what selects the scattering
+        factory over the 2-body/3-body ones.
+    q2_mode : optional
+        ScatteringQ2Mode passed through to scatter_toward().
+    tiling : int, optional
+        Grid size passed through to channels.tile() in place of a bare
+        toward(); selects the tiled factory over the 2-body one.
+    """
+
+    def __init__(self, particle, toward, fraction: float = 0.98, *,
+                 mode=None, spectator=None, pair_mass=None,
+                 variable=None, q2_mode=None, tiling=None):
+        if not (0.0 <= fraction <= 1.0):
+            raise ConfigurationError(
+                "Directed(fraction={!r}): fraction must be in [0, 1]".format(fraction))
+        self.particle = particle
+        self.toward = toward
+        self.fraction = float(fraction)
+        self.mode = mode
+        self.spectator = spectator
+        self.pair_mass = pair_mass
+        self.variable = variable
+        self.q2_mode = q2_mode
+        self.tiling = tiling
+
+    def _directed_channel(self):
+        """Build the bare directed Channel/Tiling (no fallback mixed in)."""
+        if self.tiling is not None:
+            return _channels.tile(
+                self.toward, self.tiling, daughter=self.particle,
+                mode=self.mode)
+        if self.variable is not None or self.q2_mode is not None:
+            return _channels.scatter_toward(
+                self.toward, variable=self.variable, q2_mode=self.q2_mode,
+                mode=self.mode)
+        if self.spectator is not None or self.pair_mass is not None:
+            return _channels.toward_3body(
+                self.particle, self.toward, spectator=self.spectator,
+                pair_mass=self.pair_mass, mode=self.mode)
+        return _channels.toward(self.particle, self.toward, mode=self.mode)
+
+    def to_mixture(self, signature=None) -> "_channels.Mixture":
+        """Build the channels.Mixture this Directed describes.
+
+        `signature` is accepted (and ignored) so a plain Directed and a
+        Directed.by_signature() mapping share the same call shape at the
+        Vertex.compile() call site.
+        """
+        directed = self._directed_channel()
+        if self.fraction >= 1.0:
+            return _channels.Mixture([(1.0, directed)])
+        fallback = _fallback(self.particle)
+        return (self.fraction * directed) + ((1.0 - self.fraction) * fallback)
+
+    def compile(self, signature, *, detector=None, models=None):
+        """Compile this Directed's mixture for `signature`.
+
+        Delegates to channels.Mixture.compile() after resolving
+        to_mixture(); this is the same call shape Vertex.compile() uses
+        for a bare channels.Mixture, so a Vertex's `kinematics=` accepts
+        a Directed interchangeably with a Mixture.
+        """
+        return self.to_mixture(signature).compile(
+            signature, detector=detector, models=models)
+
+    def validate(self, signature=None, models=None):
+        """Data-free configuration check, delegating to Mixture.validate()."""
+        return self.to_mixture(signature).validate(signature, models=models)
+
+    def describe(self) -> str:
+        """The g(x) expression for this Directed's mixture."""
+        return self.to_mixture().describe()
+
+    @classmethod
+    def by_signature(cls, mapping: Dict[object, Union["Directed", "_channels.Mixture"]]) -> "_DirectedBySignature":
+        """A Directed-like object compiling a different mixture per signature.
+
+        `mapping` keys are InteractionSignature (or anything else that
+        compares equal to one); values are a Directed or a bare
+        channels.Mixture. Looked up by exact signature match at compile
+        time -- there is no partial/fallback matching.
+        """
+        return _DirectedBySignature(mapping)
+
+
+class _DirectedBySignature:
+    """Directed.by_signature(...) result: dispatches to_mixture() by signature."""
+
+    __slots__ = ("_mapping",)
+
+    def __init__(self, mapping):
+        self._mapping = dict(mapping)
+
+    def _entry_for(self, signature):
+        if signature not in self._mapping:
+            raise ConfigurationError(
+                "Directed.by_signature(): no entry for signature {!r}; "
+                "known signatures: {}".format(
+                    signature, list(self._mapping.keys())))
+        return self._mapping[signature]
+
+    def to_mixture(self, signature) -> "_channels.Mixture":
+        entry = self._entry_for(signature)
+        if isinstance(entry, Directed):
+            return entry.to_mixture(signature)
+        return entry
+
+    def compile(self, signature, *, detector=None, models=None):
+        return self.to_mixture(signature).compile(
+            signature, detector=detector, models=models)
+
+    def validate(self, signature=None, models=None):
+        if signature is not None:
+            return self.to_mixture(signature).validate(signature, models=models)
+        for sig, entry in self._mapping.items():
+            mixture = entry.to_mixture(sig) if isinstance(entry, Directed) else entry
+            mixture.validate(sig, models=models)
+        return None
+
+    def describe(self) -> str:
+        parts = []
+        for sig, entry in self._mapping.items():
+            mixture = entry.to_mixture(sig) if isinstance(entry, Directed) else entry
+            parts.append("{!r}: {}".format(sig, mixture.describe()))
+        return "; ".join(parts)

--- a/python/_validation.py
+++ b/python/_validation.py
@@ -11,6 +11,8 @@ automatically.
 from collections import Counter
 
 from . import distributions as _d
+from . import particles as _particles
+from .errors import ConfigurationError
 
 DV = _d.DistributionVariable
 
@@ -253,3 +255,181 @@ def validate_reweighting_compatibility(
             "density variables (including downstream weighting factors): "
             f"{_format_density_variables(phys_density)}"
         )
+
+
+def _expand_rule_names(rule):
+    """Return the particle name(s) a child()/depth_below() rule references.
+
+    child() rules name a particle; depth_below() rules name none.
+    """
+    name = getattr(rule, "name", None)
+    return [name] if name is not None else []
+
+
+def validate_expansion_wiring(vertices):
+    """Check that a set of Vertex expand declarations forms a closed graph.
+
+    Parameters
+    ----------
+    vertices : iterable
+        Objects with ``.particle``, ``.expand`` (tuple of rules from
+        ``siren.expand.child``/``depth_below``), and ``.continue_if``.
+        An object may additionally expose ``.secondary_types`` (an
+        iterable of ParticleType/name the vertex's interactions can
+        produce); when absent, case (c) below is skipped for that
+        vertex since there is nothing to cross-check against.
+
+    Raises
+    ------
+    ConfigurationError
+        (a) An expand rule names a child particle with no registered
+            Vertex for that particle type.
+        (b) A registered secondary Vertex (any vertex other than a root,
+            i.e. one that some other vertex's expand list could reach)
+            is unreachable from every other vertex's expand list.
+        (c) A vertex declares secondaries (via ``.secondary_types``) but
+            has no expansion declaration at all (empty ``.expand``).
+    """
+    vertices = list(vertices)
+    by_particle = {}
+    for v in vertices:
+        ptype = _particles.resolve(v.particle)
+        by_particle[ptype] = v
+
+    named_children = set()
+    for v in vertices:
+        for rule in v.expand:
+            for name in _expand_rule_names(rule):
+                ptype = _particles.resolve(name)
+                named_children.add(ptype)
+                # (a) expand rule names a child with no registered Vertex.
+                if ptype not in by_particle:
+                    raise ConfigurationError(
+                        f"Vertex {v.particle!r} declares expand rule "
+                        f"child({name!r}) but no Vertex is registered for "
+                        f"particle {name!r}. Fix: register a Vertex for "
+                        f"{name!r}, or remove this expand rule."
+                    )
+            # A depth_below rule (no named particle) expands every secondary,
+            # so all of this vertex's secondary types become reachable.
+            if not _expand_rule_names(rule):
+                for t in (getattr(v, "secondary_types", None) or []):
+                    named_children.add(_particles.resolve(t))
+
+    # (b) a registered secondary Vertex unreachable from any expand list.
+    root = _particles.resolve(vertices[0].particle) if vertices else None
+    for v in vertices:
+        ptype = _particles.resolve(v.particle)
+        if ptype == root:
+            continue
+        if ptype not in named_children:
+            raise ConfigurationError(
+                f"Vertex {v.particle!r} is registered but unreachable: no "
+                f"other Vertex's expand list names it. Fix: add "
+                f"child({v.particle!r}) to the expand list of the vertex "
+                f"that produces it, or remove this Vertex."
+            )
+
+    # (c) secondaries present with no expansion declaration at all.
+    for v in vertices:
+        secondary_types = getattr(v, "secondary_types", None)
+        if not secondary_types:
+            continue
+        if not v.expand:
+            raise ConfigurationError(
+                f"Vertex {v.particle!r} has secondaries "
+                f"{list(secondary_types)!r} but declares no expand rules. "
+                f"Fix: add expand=[siren.expand.child(...)] naming which "
+                f"secondaries should recurse."
+            )
+
+
+def check_expand_vs_legacy_stopping(has_legacy_stopping, has_expand_or_continue_if):
+    """Reject configurations mixing legacy stopping_condition with expand.
+
+    Parameters
+    ----------
+    has_legacy_stopping : bool
+        True if a legacy ``stopping_condition`` callable was supplied.
+    has_expand_or_continue_if : bool
+        True if any Vertex supplies ``expand`` and/or ``continue_if``.
+
+    Raises
+    ------
+    ConfigurationError
+        If both are set: the legacy callable and the declarative
+        expand/continue_if fields are mutually exclusive.
+    """
+    if has_legacy_stopping and has_expand_or_continue_if:
+        raise ConfigurationError(
+            "Both a legacy stopping_condition callable and Vertex "
+            "expand/continue_if fields are set. Fix: use one control "
+            "surface only -- drop stopping_condition and express the "
+            "chain with Vertex(expand=[...], continue_if=...)."
+        )
+
+
+def validate_secondary_keys(*dicts_with_labels):
+    """Check that no secondary-keyed dict carries an unknown key.
+
+    Each argument is a (label, mapping) pair. The first pair is the reference
+    key set (the secondary interactions); every other mapping's keys must be a
+    subset of it. An EXTRA key -- a phase-space or weighting-mode entry for a
+    particle with no registered interaction -- raises ConfigurationError, since
+    it is almost always a typo. A MISSING key is allowed: not every secondary
+    needs a custom phase space or weighting mode.
+    """
+    pairs = [(label, mapping) for label, mapping in dicts_with_labels
+             if mapping is not None]
+    if not pairs:
+        return
+    ref_label, ref_map = pairs[0]
+    ref_keys = set(ref_map.keys())
+    for label, mapping in pairs[1:]:
+        keys = set(mapping.keys())
+        extra = keys - ref_keys
+        if extra:
+            raise ConfigurationError(
+                "{} has secondary keys {} not present in {} (keys {}). "
+                "Fix: the key is likely a typo or a stray entry; it must "
+                "match a registered secondary type.".format(
+                    label, sorted(str(k) for k in extra),
+                    ref_label, sorted(str(k) for k in ref_keys)))
+
+
+def build_template_record(signature, *, primary_mass=0.02, energy=0.05):
+    """A minimal InteractionRecord for a signature, for config-time probes.
+
+    Fills plausible small masses and a forward-moving primary; consulted only
+    by measure/density probes, never by a real Sample().
+    """
+    import math
+    import siren
+    n_sec = len(signature.secondary_types)
+    pz = math.sqrt(max(energy * energy - primary_mass * primary_mass, 0.0))
+    rec = siren.dataclasses.InteractionRecord()
+    rec.signature.primary_type = signature.primary_type
+    rec.signature.target_type = signature.target_type
+    rec.signature.secondary_types = list(signature.secondary_types)
+    rec.primary_mass = primary_mass
+    rec.primary_momentum = [energy, 0.0, 0.0, pz]
+    rec.secondary_masses = [0.001] * n_sec
+    rec.secondary_momenta = [[0.0, 0.0, 0.0, 0.0]] * n_sec
+    rec.secondary_helicities = [0] * n_sec
+    rec.interaction_vertex = [0.0, 0.0, 0.0]
+    rec.primary_initial_position = [0.0, 0.0, 0.0]
+    return rec
+
+
+def probe_channel_densities(mcps, signature, detector_model, random,
+                            *, samples_per_channel=100):
+    """Run the detector-dependent ValidateChannelDensities probe on a mixture.
+
+    Draws samples through each channel and checks the sampled density matches
+    the analytic density, surfacing a sampler/density mismatch at build time.
+    Raises whatever the engine raises (MeasureCompatibilityError,
+    WeightCalculationError) on failure; a passing probe returns its result.
+    """
+    template = build_template_record(signature)
+    return mcps.ValidateChannelDensities(
+        random, detector_model, template, samples_per_channel)

--- a/python/channels.py
+++ b/python/channels.py
@@ -1,0 +1,609 @@
+"""Channel algebra compiling to siren.injection.MultiChannelPhaseSpace.
+
+Public names: Channel, Mixture, PairMass, Tiling, isotropic, toward,
+toward_3body, scatter_toward, physical, tile.
+
+A Channel wraps one engine PhaseSpaceChannel factory that is resolved
+against a concrete InteractionSignature at compile time (daughters and
+spectators are named by particle, not by index).  Channels combine with
+`*` (rescale) and `+` (mix) into a Mixture, whose weights are normalized
+to sum to 1 at every construction.  Mixture.compile() resolves every
+Channel's factory against a signature and builds the validated
+MultiChannelPhaseSpace; Mixture.validate() runs the same compilation plus
+a detector-free ConvertDensity probe against a template record, so a bad
+3-body factorization index or an inconvertible measure combination fails
+at configuration time rather than at first weight evaluation.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, List, Optional, Sequence, Tuple, Union
+
+from . import directed_tiling as _tiling
+from . import particles as _particles
+from .errors import ConfigurationError, MeasureCompatibilityError
+
+__all__ = [
+    "Channel",
+    "Mixture",
+    "PairMass",
+    "Tiling",
+    "isotropic",
+    "toward",
+    "toward_3body",
+    "scatter_toward",
+    "physical",
+    "tile",
+]
+
+
+def _siren():
+    import siren
+    return siren
+
+
+def _resolve_index(signature, name_or_index, role):
+    """Resolve a daughter/spectator spec to a secondary index.
+
+    `name_or_index` may be an int (used directly) or a particle name/
+    ParticleType resolved against `signature.secondary_types`.  Raises
+    ConfigurationError naming the particle and the signature on an
+    absent or ambiguous match; never silently skips.
+    """
+    if isinstance(name_or_index, int):
+        return name_or_index
+    try:
+        ptype = _particles.resolve(name_or_index)
+    except (ValueError, TypeError) as e:
+        raise ConfigurationError(
+            "{}: {}".format(role, e))
+    secondaries = list(signature.secondary_types)
+    matches = [i for i, t in enumerate(secondaries) if t == ptype]
+    if not matches:
+        raise ConfigurationError(
+            "{}: particle {!r} not found among secondary_types {} of "
+            "signature {}".format(
+                role, name_or_index,
+                [str(t) for t in secondaries], signature))
+    if len(matches) > 1:
+        raise ConfigurationError(
+            "{}: particle {!r} is ambiguous among secondary_types {} of "
+            "signature {} (matched indices {})".format(
+                role, name_or_index,
+                [str(t) for t in secondaries], signature, matches))
+    return matches[0]
+
+
+# ------------------------------------------------------------------ #
+#  Shared mixture-node algebra                                        #
+# ------------------------------------------------------------------ #
+
+class _MixtureNode:
+    """Common `*`/`+` algebra for Channel and Tiling.
+
+    A node wraps a deferred factory(signature) -> engine PhaseSpaceChannel
+    plus a weight; `_build` resolves it against a concrete signature only
+    at compile/validate time.  Subclasses set `_factory`, `weight`,
+    `label` and implement `_copy_with_weight` so `*` returns the same
+    subclass.
+    """
+
+    _factory: Callable
+    weight: float
+    label: str
+
+    def _build(self, signature, *, detector=None, models=None):
+        return self._factory(signature, detector=detector, models=models)
+
+    def _copy_with_weight(self, weight):
+        raise NotImplementedError
+
+    def __rmul__(self, scalar):
+        if not isinstance(scalar, (int, float)):
+            return NotImplemented
+        return self._copy_with_weight(self.weight * float(scalar))
+
+    def __mul__(self, scalar):
+        return self.__rmul__(scalar)
+
+    def __add__(self, other):
+        if isinstance(other, _MixtureNode):
+            return Mixture([(self.weight, self), (other.weight, other)])
+        if isinstance(other, Mixture):
+            return Mixture([(self.weight, self)] + other._scaled_entries())
+        return NotImplemented
+
+    def __radd__(self, other):
+        if isinstance(other, Mixture):
+            return Mixture(other._scaled_entries() + [(self.weight, self)])
+        return NotImplemented
+
+    def describe(self) -> str:
+        return self.label
+
+
+class Channel(_MixtureNode):
+    """One weighted spec node wrapping a deferred engine-channel factory.
+
+    `factory(signature)` builds the concrete engine PhaseSpaceChannel for
+    that signature; it is called only at compile/validate time, never at
+    construction, so a Channel can be built before any signature is known.
+    """
+
+    def __init__(self, factory: Callable, weight: float = 1.0,
+                 label: str = "channel"):
+        self._factory = factory
+        self.weight = float(weight)
+        self.label = label
+
+    def _copy_with_weight(self, weight):
+        return Channel(self._factory, weight, self.label)
+
+
+# ------------------------------------------------------------------ #
+#  Mixture                                                             #
+# ------------------------------------------------------------------ #
+
+class Mixture:
+    """A normalized weighted list of Channels (and Tilings).
+
+    Always normalized so the stored weights sum to 1: at construction and
+    after every `+`.  Rejects an empty, negative, or non-finite weight set
+    with ConfigurationError.
+    """
+
+    def __init__(self, entries: Sequence[Tuple[float, "Channel"]]):
+        entries = list(entries)
+        if not entries:
+            raise ConfigurationError("Mixture: cannot construct from an empty list of channels")
+        for w, ch in entries:
+            if not math.isfinite(w):
+                raise ConfigurationError(
+                    "Mixture: non-finite weight {!r} for channel {!r}".format(w, ch.describe()))
+            if w < 0.0:
+                raise ConfigurationError(
+                    "Mixture: negative weight {!r} for channel {!r}".format(w, ch.describe()))
+        total = sum(w for w, _ in entries)
+        if not (math.isfinite(total) and total > 0.0):
+            raise ConfigurationError(
+                "Mixture: weights sum to {!r}, must be finite and positive".format(total))
+        self._entries: List[Tuple[float, "Channel"]] = [
+            (w / total, ch) for w, ch in entries]
+        # A composition scale carried by `*`: `p * mixture` sets it so that
+        # `p * mix_a + q * mix_b` gives each sub-channel its p (or q) share of
+        # the combined mixture. It never affects a standalone mixture's
+        # normalized `_entries`.
+        self._scale = 1.0
+
+    def _scaled_entries(self):
+        """The entries as (scale * relative_weight, channel) pairs."""
+        return [(self._scale * w, ch) for w, ch in self._entries]
+
+    def __add__(self, other):
+        if isinstance(other, _MixtureNode):
+            return Mixture(self._scaled_entries() + [(other.weight, other)])
+        if isinstance(other, Mixture):
+            return Mixture(self._scaled_entries() + other._scaled_entries())
+        return NotImplemented
+
+    def __radd__(self, other):
+        if isinstance(other, _MixtureNode):
+            return Mixture([(other.weight, other)] + self._scaled_entries())
+        return NotImplemented
+
+    def __rmul__(self, scalar):
+        if not isinstance(scalar, (int, float)):
+            return NotImplemented
+        # Compose the scale multiplicatively so nested rescaling accumulates:
+        # `p * (q * mixture)` carries p*q, matching _MixtureNode.__rmul__.
+        scaled = Mixture(list(self._entries))
+        scaled._scale = self._scale * float(scalar)
+        return scaled
+
+    __mul__ = __rmul__
+
+    def describe(self) -> str:
+        parts = ["{:.2f} * {}".format(w, ch.describe()) for w, ch in self._entries]
+        return " + ".join(parts)
+
+    # -------------------------------------------------------------- #
+    #  Compilation                                                    #
+    # -------------------------------------------------------------- #
+
+    def _flatten(self, signature, *, detector=None, models=None):
+        """Resolve every entry to (weight, engine PhaseSpaceChannel)."""
+        engine_channels = []
+        weights = []
+        for w, ch in self._entries:
+            built = ch._build(signature, detector=detector, models=models)
+            engine_channels.append(built)
+            weights.append(w)
+        return engine_channels, weights
+
+    def compile(self, signature, *, detector=None, models=None):
+        """Build the siren.injection.MultiChannelPhaseSpace for `signature`.
+
+        Uses the validating constructor: it normalizes the weights and
+        throws MeasureCompatibilityError on a fatal topology/measure
+        incompatibility.
+        """
+        siren = _siren()
+        engine_channels, weights = self._flatten(
+            signature, detector=detector, models=models)
+        return siren.injection.MultiChannelPhaseSpace(engine_channels, weights)
+
+    def validate(self, signature=None, *, models=None):
+        """Data-free configuration check.
+
+        Runs (a) compilation against a template signature via the
+        validating MultiChannelPhaseSpace ctor, which normalizes weights
+        and raises MeasureCompatibilityError on a fatal incompatibility,
+        and (b) a ConvertDensity probe on a template record built from the
+        signature's masses, surfacing bad 3-body factorization indices at
+        configuration time.  Does not run the detector-dependent
+        ValidateChannelDensities probe (that runs in Injector._build).
+
+        `models=` is forwarded to compile() exactly as compile() accepts
+        it; required whenever the mixture holds a physical() channel (see
+        physical()'s docstring).
+        """
+        siren = _siren()
+        sig = signature if signature is not None else _template_signature()
+        mcps = self.compile(sig, models=models)  # raises MeasureCompatibilityError if fatal
+
+        record = _template_record(sig)
+        topology = mcps.CommonTopology()
+        common_measure = mcps.CommonMeasure()
+        for ch in mcps.channels:
+            measure = ch.Measure()
+            if measure == common_measure:
+                continue
+            try:
+                siren.injection.ConvertDensity(
+                    1.0, measure, common_measure, topology, record)
+            except MeasureCompatibilityError:
+                # SolidAngleLab conversions outside Decay2Body topology are
+                # unconvertible by design; any other channel combination that
+                # cannot convert is a genuine configuration error.
+                if topology != siren.injection.PhaseSpaceTopology.Decay2Body and (
+                        measure.type == siren.injection.PhaseSpaceMeasureType.SolidAngleLab
+                        or common_measure.type == siren.injection.PhaseSpaceMeasureType.SolidAngleLab):
+                    continue
+                raise
+        return mcps
+
+
+# ------------------------------------------------------------------ #
+#  Template signature / record for detector-free validation           #
+# ------------------------------------------------------------------ #
+
+def _template_signature():
+    siren = _siren()
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.particles.N4 if hasattr(siren.particles, "N4") else siren.particles.NuMu
+    sig.target_type = siren.dataclasses.ParticleType.Decay
+    sig.secondary_types = [siren.particles.NuLight, siren.particles.Gamma]
+    return sig
+
+
+def _template_record(signature, primary_mass=0.02, energy=0.05):
+    """A minimal InteractionRecord for the given signature.
+
+    Mirrors the idiom in tests/python/test_density_breakdown.py: plausible
+    small masses, a forward-moving primary, and a vertex at the origin.
+    Secondary masses are set to a small common value (no physical model is
+    consulted -- this record only feeds the detector-free ConvertDensity
+    probe, not any Sample()).
+    """
+    siren = _siren()
+    n_sec = len(signature.secondary_types)
+    m_sec = 0.001
+    pz = math.sqrt(max(energy * energy - primary_mass * primary_mass, 0.0))
+    rec = siren.dataclasses.InteractionRecord()
+    rec.signature.primary_type = signature.primary_type
+    rec.signature.target_type = signature.target_type
+    rec.signature.secondary_types = list(signature.secondary_types)
+    rec.primary_mass = primary_mass
+    rec.primary_momentum = [energy, 0.0, 0.0, pz]
+    rec.secondary_masses = [m_sec] * n_sec
+    rec.secondary_momenta = [[0.0, 0.0, 0.0, 0.0]] * n_sec
+    rec.secondary_helicities = [0] * n_sec
+    rec.interaction_vertex = [0.0, 0.0, 0.0]
+    rec.primary_initial_position = [0.0, 0.0, 0.0]
+    return rec
+
+
+# ------------------------------------------------------------------ #
+#  PairMass                                                            #
+# ------------------------------------------------------------------ #
+
+class PairMass:
+    """Invariant-mass sampling law for a 3-body directed channel's pair.
+
+    Carries the fields toward_3body maps onto the
+    DetectorDirected3BodyChannel ctor: mass_mode, resonance_mass,
+    resonance_width, power_law_nu, power_law_offset, mass_cdf_nodes,
+    mass_cdf_values.
+    """
+
+    def __init__(self, mass_mode, resonance_mass=0.0, resonance_width=0.0,
+                 power_law_nu=0.8, power_law_offset=0.0,
+                 mass_cdf_nodes=(), mass_cdf_values=()):
+        self.mass_mode = mass_mode
+        self.resonance_mass = resonance_mass
+        self.resonance_width = resonance_width
+        self.power_law_nu = power_law_nu
+        self.power_law_offset = power_law_offset
+        self.mass_cdf_nodes = list(mass_cdf_nodes)
+        self.mass_cdf_values = list(mass_cdf_values)
+
+    @classmethod
+    def uniform(cls):
+        siren = _siren()
+        return cls(siren.injection.InvariantMassMode.Uniform)
+
+    @classmethod
+    def breit_wigner(cls, m, w):
+        siren = _siren()
+        return cls(siren.injection.InvariantMassMode.BreitWigner,
+                    resonance_mass=m, resonance_width=w)
+
+    @classmethod
+    def power_law(cls, nu, offset=0.0):
+        siren = _siren()
+        return cls(siren.injection.InvariantMassMode.PowerLaw,
+                    power_law_nu=nu, power_law_offset=offset)
+
+    @classmethod
+    def tabulated(cls, nodes, values):
+        siren = _siren()
+        return cls(siren.injection.InvariantMassMode.Tabulated,
+                    mass_cdf_nodes=nodes, mass_cdf_values=values)
+
+
+# ------------------------------------------------------------------ #
+#  Factories                                                           #
+# ------------------------------------------------------------------ #
+
+def isotropic(daughter: Union[int, str] = 0) -> Channel:
+    """Isotropic2BodyChannel wrapped as a Channel.
+
+    `daughter` is either a secondary index or a particle name/ParticleType
+    resolved against the signature at compile time.
+    """
+    def factory(signature, *, detector=None, models=None):
+        siren = _siren()
+        idx = _resolve_index(signature, daughter, "isotropic(daughter=...)")
+        return siren.injection.Isotropic2BodyChannel(idx)
+
+    label = "isotropic" if daughter == 0 else "isotropic({!r})".format(daughter)
+    return Channel(factory, weight=1.0, label=label)
+
+
+def toward(daughter: Union[int, str], target, *, mode=None, volume=-1.0,
+           fraction: Optional[float] = None) -> Union[Channel, Mixture]:
+    """DetectorDirected2BodyChannel toward `target`, daughter named by particle.
+
+    If `fraction` is given and < 1, returns the mixture
+    `fraction*toward(...) + (1-fraction)*isotropic(...)` (a physical
+    fallback for events that miss the target); otherwise a bare directed
+    Channel.
+    """
+    siren = _siren()
+    if mode is None:
+        mode = siren.injection.DirectedMode.Volume
+
+    def factory(signature, *, detector=None, models=None):
+        idx = _resolve_index(signature, daughter, "toward(daughter=...)")
+        return siren.injection.DetectorDirected2BodyChannel(
+            target, idx, mode, volume)
+
+    label = "toward({!r})".format(daughter)
+    directed = Channel(factory, weight=1.0, label=label)
+
+    if fraction is None or fraction >= 1.0:
+        return directed
+    if not (0.0 <= fraction < 1.0):
+        raise ConfigurationError(
+            "toward(fraction={!r}): fraction must be in [0, 1)".format(fraction))
+    return fraction * directed + (1.0 - fraction) * isotropic(daughter)
+
+
+def toward_3body(directed: Union[int, str], target, *,
+                  spectator: Optional[Union[int, str]] = None,
+                  strategy: str = "recursive",
+                  pair_mass: Optional[PairMass] = None,
+                  mode=None) -> Channel:
+    """DetectorDirected3BodyChannel toward `target`.
+
+    strategy='direct' uses the direct ctor (directed_index only, other two
+    indices inferred ascending). strategy='recursive' uses the recursive
+    ctor (spectator/pair indices resolved per signature; `spectator`
+    selects the spectator daughter, the other two secondaries become the
+    pair, with `directed` as the directed member of the pair).
+
+    The channel topology is inferred per signature: a real target type
+    tags the channel Scatter2to3 (2->3 scattering), the Decay marker tags
+    it Decay3Body.
+    """
+    siren = _siren()
+    if mode is None:
+        mode = siren.injection.DirectedMode.Volume
+    if pair_mass is None:
+        pair_mass = PairMass.uniform()
+    if strategy not in ("recursive", "direct"):
+        raise ConfigurationError(
+            "toward_3body(strategy={!r}): must be 'recursive' or 'direct'".format(strategy))
+
+    def factory(signature, *, detector=None, models=None):
+        directed_idx = _resolve_index(signature, directed, "toward_3body(directed=...)")
+        decay_marker = siren.dataclasses.ParticleType.Decay
+        topology = (siren.injection.PhaseSpaceTopology.Decay3Body
+                    if signature.target_type == decay_marker
+                    else siren.injection.PhaseSpaceTopology.Scatter2to3)
+        common_kwargs = dict(
+            topology=topology,
+            mass_mode=pair_mass.mass_mode,
+            resonance_mass=pair_mass.resonance_mass,
+            resonance_width=pair_mass.resonance_width,
+            power_law_nu=pair_mass.power_law_nu,
+            power_law_offset=pair_mass.power_law_offset,
+            mode=mode,
+            mass_cdf_nodes=pair_mass.mass_cdf_nodes,
+            mass_cdf_values=pair_mass.mass_cdf_values,
+        )
+        if strategy == "direct":
+            return siren.injection.DetectorDirected3BodyChannel(
+                factorization=siren.injection.ThreeBodyMode.Direct,
+                target=target, directed_index=directed_idx, **common_kwargs)
+
+        n_sec = len(signature.secondary_types)
+        if spectator is None:
+            raise ConfigurationError(
+                "toward_3body(strategy='recursive'): spectator= is required "
+                "to resolve the pair indices")
+        spectator_idx = _resolve_index(signature, spectator, "toward_3body(spectator=...)")
+        others = [i for i in range(n_sec) if i != spectator_idx]
+        if directed_idx not in others:
+            raise ConfigurationError(
+                "toward_3body: directed index {} coincides with spectator "
+                "index {} for signature {}".format(directed_idx, spectator_idx, signature))
+        pair_first_idx, pair_second_idx = others[0], others[1]
+        return siren.injection.DetectorDirected3BodyChannel(
+            factorization=siren.injection.ThreeBodyMode.Recursive,
+            target=target, spectator_index=spectator_idx,
+            pair_first_index=pair_first_idx, pair_second_index=pair_second_idx,
+            directed_index=directed_idx, **common_kwargs)
+
+    label = "toward_3body({!r}, strategy={!r})".format(directed, strategy)
+    return Channel(factory, weight=1.0, label=label)
+
+
+def scatter_toward(target, *, daughter=None, variable=None, q2_mode=None,
+                    mediator_mass=0.0, mode=None) -> Channel:
+    """DetectorDirectedScatteringChannel toward `target`.
+
+    `daughter` names which outgoing particle is directed toward the target,
+    either as a secondary index or a particle name/ParticleType resolved
+    against the signature (the same resolution toward() uses for its
+    daughter). The default selects the index-0 secondary.
+    """
+    siren = _siren()
+    if mode is None:
+        mode = siren.injection.DirectedMode.Volume
+    if variable is None:
+        variable = siren.injection.ScatteringVariable.Q2
+    if q2_mode is None:
+        q2_mode = siren.injection.ScatteringQ2Mode.Geometry
+
+    def factory(signature, *, detector=None, models=None):
+        idx = (0 if daughter is None
+               else _resolve_index(signature, daughter,
+                                   "scatter_toward(daughter=...)"))
+        return siren.injection.DetectorDirectedScatteringChannel(
+            target, idx, variable, mode, q2_mode, mediator_mass)
+
+    label = ("scatter_toward" if daughter is None
+             else "scatter_toward({!r})".format(daughter))
+    return Channel(factory, weight=1.0, label=label)
+
+
+def physical() -> Channel:
+    """Late-binds PhysicalDecayChannel or PhysicalCrossSectionChannel.
+
+    Resolution happens at compile time and needs the vertex's interaction
+    model(s), passed as `models=[...]` to Mixture.compile()/validate().
+    Exactly one model matching the signature (by GetPossibleSignatures, if
+    available, else taken as-is) must be supplied; otherwise raises
+    ConfigurationError with a one-line fix.
+    """
+    def factory(signature, *, detector=None, models=None):
+        siren = _siren()
+        if not models:
+            raise ConfigurationError(
+                "physical(): no interaction model available to late-bind; "
+                "pass models=[<Decay or CrossSection>] to Mixture.compile()/"
+                "validate()")
+        candidates = list(models)
+        if len(candidates) > 1:
+            raise ConfigurationError(
+                "physical(): {} candidate models supplied, expected exactly "
+                "one; pass models=[<the single Decay or CrossSection for "
+                "this vertex>]".format(len(candidates)))
+        model = candidates[0]
+        if isinstance(model, siren.interactions.Decay):
+            return siren.injection.PhysicalDecayChannel(model, signature)
+        if isinstance(model, siren.interactions.CrossSection):
+            return siren.injection.PhysicalCrossSectionChannel(model, signature)
+        raise ConfigurationError(
+            "physical(): model {!r} is neither a Decay nor a CrossSection".format(model))
+
+    return Channel(factory, weight=1.0, label="physical")
+
+
+# ------------------------------------------------------------------ #
+#  Tiling                                                              #
+# ------------------------------------------------------------------ #
+
+class Tiling(_MixtureNode):
+    """A grid/disjoint tiling of a geometry, treated as one Channel-like unit.
+
+    Wraps directed_tiling.build_grid_tiling/disjointify; the optimizer
+    tunes the tiling's inner weights as one nested level (see
+    NestedMixtureChannel), never touching the outer mixture's weight for
+    it directly.  Participates in Mixture algebra the same way a Channel
+    does.
+    """
+
+    def __init__(self, factory: Callable, weight: float = 1.0,
+                 label: str = "tile"):
+        self._factory = factory
+        self.weight = float(weight)
+        self.label = label
+
+    def _copy_with_weight(self, weight):
+        return Tiling(self._factory, weight, self.label)
+
+
+def tile(geometry, grid: int, method: str = "disjoint",
+         daughter: Union[int, str] = 0, mode=None,
+         volume_fn: Optional[Callable] = None) -> Tiling:
+    """Tile `geometry` into a grid of directed sub-channels.
+
+    `grid` is the number of cells per axis (an axis-aligned Box region is
+    required, matching directed_tiling.grid_cells).  method='disjoint'
+    routes through directed_tiling.disjointify on the grid cells (already
+    disjoint by construction, so disjointify is a no-op composition step
+    kept for a uniform call path); any other method raises
+    ConfigurationError.  Grid cells of an axis-aligned Box have exact,
+    equal volumes, which the tiling supplies to the Volume-mode channels;
+    pass `volume_fn` (a callable geometry -> volume) to override.
+    """
+    if method != "disjoint":
+        raise ConfigurationError(
+            "tile(method={!r}): only 'disjoint' is supported".format(method))
+
+    def factory(signature, *, detector=None, models=None):
+        siren = _siren()
+        if mode is None:
+            resolved_mode = siren.injection.DirectedMode.Volume
+        else:
+            resolved_mode = mode
+        idx = _resolve_index(signature, daughter, "tile(daughter=...)")
+        cells = _tiling.grid_cells(geometry, grid)
+        disjoint_cells = _tiling.disjointify(cells)
+        chan_factory = _tiling.default_2body_factory(idx, resolved_mode)
+        if volume_fn is not None:
+            tile_volume_fn = volume_fn
+        else:
+            # Equal-size grid cells of an axis-aligned Box; disjointify
+            # subtracts non-overlapping siblings, so each tile keeps its
+            # cell volume exactly.
+            cell_volume = (
+                geometry.X * geometry.Y * geometry.Z) / float(len(cells))
+            tile_volume_fn = lambda _geo: cell_volume
+        return _tiling._wrap(
+            disjoint_cells, chan_factory, True, tile_volume_fn)
+
+    return Tiling(factory, weight=1.0, label="tile(grid={})".format(grid))

--- a/python/errors.py
+++ b/python/errors.py
@@ -1,0 +1,58 @@
+"""Typed error vocabulary for SIREN's high-level interface.
+
+Re-exports the pybind-translated C++ exceptions (registered on
+``siren.utilities`` with a ``RuntimeError`` base) under one namespace and adds
+the pure-Python errors the Layer-2 surface raises. Every name here derives from
+``RuntimeError`` (or ``Exception``) so existing ``pytest.raises(RuntimeError)``
+call sites keep matching.
+"""
+
+from . import utilities as _utilities
+
+# ---- C++ exceptions surfaced through pybind (siren.utilities) ----
+ConfigurationError = _utilities.ConfigurationError
+MeasureCompatibilityError = _utilities.MeasureCompatibilityError
+WeightCalculationError = _utilities.WeightCalculationError
+AddProcessFailure = _utilities.AddProcessFailure
+SecondaryProcessFailure = _utilities.SecondaryProcessFailure
+InjectionFailure = _utilities.InjectionFailure
+PythonImplementationError = _utilities.PythonImplementationError
+
+
+# ---- Pure-Python errors for the Layer-2 surface ----
+class ClosureError(RuntimeError):
+    """A sampler and its density disagree beyond tolerance.
+
+    Raised by the closure gauge when a model's FinalStateProbability does not
+    match the distribution its SampleFinalState draws from.
+    """
+
+
+class NotSerializableError(RuntimeError):
+    """An injector or weighter cannot be round-tripped to disk.
+
+    Raised by ``Injector.save`` when the configuration holds objects that do
+    not survive serialization: Python trampoline-derived interactions or
+    distributions, or a non-Propagated weighting mode / per-signature phase
+    space (neither is archived by the C++ process, so a reloaded injector would
+    silently carry the wrong physics).
+    """
+
+    def __init__(self, message, offenders=None):
+        super().__init__(message)
+        self.offenders = list(offenders) if offenders is not None else []
+
+
+class InjectionShortfall(RuntimeError, UserWarning):
+    """Generation produced fewer successes than requested.
+
+    Both an exception and a warning: ``on_shortfall='raise'`` raises it,
+    ``'warn'`` passes the instance to ``warnings.warn``. Carries the
+    ``InjectionReport`` describing where attempts were lost. Raised when the
+    attempt budget is exhausted or efficiency falls below ``min_efficiency``
+    before the requested count is reached.
+    """
+
+    def __init__(self, message, report=None):
+        super().__init__(message)
+        self.report = report

--- a/python/expand.py
+++ b/python/expand.py
@@ -1,0 +1,192 @@
+"""Expansion vocabulary for chain-vertex secondary recursion.
+
+An expansion rule is an instruction attached to a chain vertex saying
+which of its secondaries should recurse into their own vertex. Rules are
+combined with the vertex's optional ``continue_if`` predicate and
+compiled into one ``stopping_condition(tree, parent, i)`` callable with
+the engine's polarity: the engine calls it for secondary index ``i`` of
+``parent`` and, when it returns True, that secondary is pruned (not
+expanded). False means the secondary is expanded. See
+``Injector.SetStoppingCondition`` and the call site in
+``projects/injection/private/Injector.cxx``.
+
+Rule types
+----------
+``child(name, index=None)``
+    Expand the secondary named ``name`` (a particle name or
+    ParticleType, resolved against the parent signature at compile
+    time). If ``index`` is given, only the occurrence of that particle
+    at that position among the parent's secondaries matches.
+
+``depth_below(n)``
+    Expand every secondary while ``parent.depth(tree) < n``. Independent
+    of particle identity.
+
+Vertex description (duck-typed)
+--------------------------------
+``compile_expansion`` and ``validate_expansion_wiring`` (in
+``_validation.py``) accept ``vertices`` as any iterable of objects with:
+
+``particle``
+    The ParticleType or particle name this vertex produces/handles
+    (i.e. the parent particle whose secondaries this vertex's ``expand``
+    list governs).
+``expand``
+    A tuple of rule objects from ``child()`` / ``depth_below()``.
+``continue_if``
+    ``None`` or a callable ``(tree, parent, i) -> bool``; True means the
+    secondary may proceed (subject also to the expand-list match), False
+    forces a prune regardless of the expand list.
+
+A plain namedtuple (``VertexSpec`` below) satisfies this; any object
+exposing the same three attributes works too. This module never imports
+``python/vertex.py`` -- the real Vertex compiler builds these records
+from Vertex objects itself.
+"""
+
+from __future__ import annotations
+
+from collections import namedtuple
+
+from . import particles as _particles
+
+__all__ = [
+    "child",
+    "depth_below",
+    "compile_expansion",
+    "VertexSpec",
+]
+
+
+_VertexSpecBase = namedtuple(
+    "VertexSpec", ["particle", "expand", "continue_if", "secondary_types"]
+)
+_VertexSpecBase.__new__.__defaults__ = (None,)
+
+
+class VertexSpec(_VertexSpecBase):
+    """Minimal duck-typed vertex description consumed by this module.
+
+    `secondary_types` is optional and only consulted by
+    `_validation.validate_expansion_wiring` for its "secondaries with no
+    expansion declaration" check; `compile_expansion` never reads it.
+    """
+
+
+class _ChildRule:
+    """Expansion rule matching a secondary by particle type (and index)."""
+
+    __slots__ = ("name", "index")
+
+    def __init__(self, name, index=None):
+        self.name = name
+        self.index = index
+
+    def _matches(self, ptype, i):
+        if self.index is not None and i != self.index:
+            return False
+        return ptype == _particles.resolve(self.name)
+
+    def __repr__(self):
+        if self.index is None:
+            return f"child({self.name!r})"
+        return f"child({self.name!r}, index={self.index!r})"
+
+
+class _DepthBelowRule:
+    """Expansion rule matching every secondary while parent depth < n."""
+
+    __slots__ = ("n",)
+
+    def __init__(self, n):
+        self.n = n
+
+    def _matches_depth(self, depth):
+        return depth < self.n
+
+    def __repr__(self):
+        return f"depth_below({self.n!r})"
+
+
+def child(name, index=None):
+    """Return a rule expanding the secondary named `name`.
+
+    Parameters
+    ----------
+    name : str or ParticleType
+        Particle identifying which secondary to expand.
+    index : int, optional
+        Restrict the match to the secondary at this position among the
+        parent's ``secondary_types``. Without it, every occurrence of
+        `name` matches.
+    """
+    return _ChildRule(name, index=index)
+
+
+def depth_below(n):
+    """Return a rule expanding all secondaries while parent depth < n."""
+    return _DepthBelowRule(n)
+
+
+def _index_vertices_by_particle(vertices):
+    """Map resolved ParticleType -> vertex spec, first match wins."""
+    by_particle = {}
+    for v in vertices:
+        ptype = _particles.resolve(v.particle)
+        if ptype not in by_particle:
+            by_particle[ptype] = v
+    return by_particle
+
+
+def _rule_permits(rule, ptype, i, depth):
+    if isinstance(rule, _ChildRule):
+        return rule._matches(ptype, i)
+    if isinstance(rule, _DepthBelowRule):
+        return rule._matches_depth(depth)
+    return False
+
+
+def compile_expansion(vertices):
+    """Compile per-vertex expand rules into one stopping_condition callable.
+
+    Parameters
+    ----------
+    vertices : iterable
+        Objects with ``.particle``, ``.expand`` (tuple of rules from
+        ``child()``/``depth_below()``), and ``.continue_if``
+        (callable or None). See module docstring for the exact contract.
+
+    Returns
+    -------
+    callable
+        ``stopping_condition(tree, parent, i) -> bool`` in the engine's
+        native polarity: True prunes secondary `i` of `parent`, False
+        expands it. Safe to pass directly to
+        ``Injector.SetStoppingCondition`` / the ``stopping_condition``
+        constructor argument.
+    """
+    by_particle = _index_vertices_by_particle(vertices)
+
+    def stopping_condition(tree, parent, i):
+        primary_type = parent.record.signature.primary_type
+        vertex = by_particle.get(primary_type)
+        if vertex is None:
+            return True
+
+        secondary_types = parent.record.signature.secondary_types
+        ptype = secondary_types[i]
+        depth = parent.depth(tree)
+
+        matched = any(
+            _rule_permits(rule, ptype, i, depth) for rule in vertex.expand
+        )
+        if not matched:
+            return True
+
+        if vertex.continue_if is not None:
+            if not vertex.continue_if(tree, parent, i):
+                return True
+
+        return False
+
+    return stopping_condition

--- a/python/vertex.py
+++ b/python/vertex.py
@@ -1,0 +1,262 @@
+"""Vertex: one chain node's interactions, distributions, and phase space.
+
+A Vertex describes everything the engine needs to compile one
+PrimaryInjectionProcess (root) or SecondaryInjectionProcess (non-root)
+node: which particle it is, which Decay/CrossSection models drive it,
+which injection distributions sample its free parameters, and which
+channels.Mixture/_directed.Directed biases its phase-space sampling.
+Vertex.compile() builds the engine process object; Vertex.as_vertex_spec()
+builds the expand.VertexSpec consumed by expand.compile_expansion().
+
+A Vertex holds strong references to every Python object it is handed
+(models, distributions, mixtures) for the lifetime of the Vertex, so a
+Python-subclassed trampoline (a DarkNews model, a custom distribution)
+is not collected out from under the compiled C++ process, which only
+holds it via a pybind trampoline pointer.
+"""
+
+from __future__ import annotations
+
+from . import particles as _particles
+from . import expand as _expand
+from .errors import ConfigurationError
+
+__all__ = ["Vertex"]
+
+
+def _siren():
+    import siren
+    return siren
+
+
+def _resolve_weighting_mode(weighting):
+    """Resolve `weighting` to an engine VertexWeightingMode.
+
+    Accepts an already-built VertexWeightingMode (from either
+    siren.injection.VertexWeightingMode -- where it actually lives -- or
+    the siren.Propagated / siren.Fixed shorthand), or None (defaults to
+    Propagated()).
+    """
+    siren = _siren()
+    if weighting is None:
+        return siren.injection.VertexWeightingMode.Propagated()
+    return weighting
+
+
+def _as_list(interactions):
+    if interactions is None:
+        return []
+    if isinstance(interactions, (list, tuple)):
+        return list(interactions)
+    return [interactions]
+
+
+def _model_signatures(model):
+    """GetPossibleSignatures() for a Decay or CrossSection model.
+
+    Both bases expose the same method name; this just centralizes the
+    call so Vertex.compile() does not care which base `model` derives
+    from.
+    """
+    return list(model.GetPossibleSignatures())
+
+
+def _as_compilable(kinematics):
+    """Normalize `kinematics` to something exposing compile(sig, ...).
+
+    channels.Mixture, _directed.Directed, and _directed's
+    by_signature() result all already expose compile(signature, *,
+    detector, models); a bare channels.Channel/Tiling (the un-mixed
+    single-channel case) does not, so it is wrapped in a
+    one-entry Mixture.
+    """
+    if hasattr(kinematics, "compile"):
+        return kinematics
+    from . import channels as _channels
+    if isinstance(kinematics, _channels._MixtureNode):
+        return _channels.Mixture([(kinematics.weight, kinematics)])
+    raise ConfigurationError(
+        "Vertex(kinematics=...): expected a channels.Mixture, "
+        "channels.Channel/Tiling, or _directed.Directed, got {!r}".format(
+            type(kinematics).__name__))
+
+
+class Vertex:
+    """One chain node: particle, interactions, distributions, phase space.
+
+    Parameters
+    ----------
+    particle : str or ParticleType
+        The particle this vertex is compiled for (the primary of the
+        root vertex, or the secondary type of a non-root vertex).
+    interactions : Decay/CrossSection or list thereof
+        The interaction model(s) driving this vertex.
+    distributions : list, optional
+        PrimaryInjectionDistribution / SecondaryInjectionDistribution
+        objects sampling this vertex's free parameters.
+    position : optional
+        Convenience vertex-position distribution, appended to
+        `distributions` if given.
+    physical : list, optional
+        Physical-side distributions kept on the Vertex for the Weighter
+        to read; not consumed by Vertex.compile() itself.
+    kinematics : channels.Mixture, channels.Channel, _directed.Directed, optional
+        Phase-space biasing description, compiled once per signature
+        enumerated from `interactions`. None means no phase space is
+        registered (the engine's default sampler is used).
+    weighting : VertexWeightingMode, optional
+        Defaults to Propagated(). Accepts the engine enum value however
+        it is exposed as siren.injection.VertexWeightingMode, or the
+        siren.Propagated / siren.Fixed shorthand.
+    expand : tuple, optional
+        Expansion rules from expand.child() / expand.depth_below().
+    continue_if : callable, optional
+        (tree, parent, i) -> bool predicate consulted by
+        expand.compile_expansion().
+    label : str, optional
+        Human-readable label, not consumed by the engine.
+
+    Everything after `interactions` is keyword-only. Field storage uses
+    __slots__: assigning an unknown attribute raises AttributeError
+    instead of silently creating a new one, so a typo'd field name (a
+    common failure mode of a duck-typed config surface) is caught
+    immediately rather than silently ignored.
+    """
+
+    __slots__ = (
+        "particle",
+        "_resolved_particle",
+        "interactions",
+        "distributions",
+        "physical",
+        "kinematics",
+        "weighting",
+        "expand",
+        "continue_if",
+        "label",
+    )
+
+    def __init__(self, particle, interactions, *, distributions=None,
+                 position=None, physical=None, kinematics=None,
+                 weighting=None, expand=(), continue_if=None, label=None):
+        self.particle = particle
+        self._resolved_particle = _particles.resolve(particle)
+        self.interactions = _as_list(interactions)
+        if not self.interactions:
+            raise ConfigurationError(
+                "Vertex(particle={!r}): interactions must be a Decay/"
+                "CrossSection or a non-empty list thereof".format(particle))
+
+        dists = list(distributions) if distributions is not None else []
+        if position is not None:
+            dists.append(position)
+        self.distributions = dists
+
+        self.physical = list(physical) if physical is not None else []
+        self.kinematics = kinematics
+        self.weighting = weighting
+        self.expand = tuple(expand)
+        self.continue_if = continue_if
+        self.label = label
+
+    # ------------------------------------------------------------------ #
+    #  Introspection                                                       #
+    # ------------------------------------------------------------------ #
+
+    def is_primary(self, *, is_primary):
+        """Return whether this Vertex would compile as a primary process."""
+        return bool(is_primary)
+
+    def is_secondary(self, *, is_primary):
+        """Return whether this Vertex would compile as a secondary process."""
+        return not is_primary
+
+    def _all_signatures(self):
+        """(model, signature) pairs for every model's possible signatures."""
+        pairs = []
+        for model in self.interactions:
+            for sig in _model_signatures(model):
+                pairs.append((model, sig))
+        return pairs
+
+    def as_vertex_spec(self):
+        """Build the expand.VertexSpec for this Vertex.
+
+        `secondary_types` is the union, across every signature this
+        vertex's models can produce, of the secondary particle types --
+        consulted only by expand._validation's "secondaries with no
+        expansion declaration" check, not by compile_expansion itself.
+        """
+        seen = []
+        for _model, sig in self._all_signatures():
+            for t in sig.secondary_types:
+                if t not in seen:
+                    seen.append(t)
+        return _expand.VertexSpec(
+            particle=self._resolved_particle,
+            expand=self.expand,
+            continue_if=self.continue_if,
+            secondary_types=seen,
+        )
+
+    # ------------------------------------------------------------------ #
+    #  Compilation                                                         #
+    # ------------------------------------------------------------------ #
+
+    def compile(self, *, is_primary, detector=None):
+        """Compile this Vertex into an engine process.
+
+        Returns a siren.injection.PrimaryInjectionProcess when
+        `is_primary` is True, else a SecondaryInjectionProcess. Builds
+        the InteractionCollection from `self.interactions`, assigns
+        `self.distributions`, registers a phase space for every
+        signature this vertex's models can produce (when `kinematics`
+        is not None), and sets `weighting_mode`.
+        """
+        siren = _siren()
+
+        interaction_collection = siren.interactions.InteractionCollection(
+            self._resolved_particle, self.interactions)
+
+        if is_primary:
+            process = siren.injection.PrimaryInjectionProcess(
+                self._resolved_particle, interaction_collection)
+        else:
+            process = siren.injection.SecondaryInjectionProcess(
+                self._resolved_particle, interaction_collection)
+
+        process.distributions = self.distributions
+
+        if self.kinematics is not None:
+            compilable = _as_compilable(self.kinematics)
+            seen_signatures = {}
+            for model, sig in self._all_signatures():
+                # Two models sharing a signature would each register their own
+                # phase space under it, the second silently replacing the
+                # first even though InteractionCollection still selects both.
+                if sig in seen_signatures:
+                    raise ConfigurationError(
+                        "Vertex(particle={!r}): models {!r} and {!r} both "
+                        "produce signature {}; combine colliding-signature "
+                        "models into a single channels.Mixture per "
+                        "signature".format(
+                            self.particle,
+                            type(seen_signatures[sig]).__name__,
+                            type(model).__name__, sig))
+                seen_signatures[sig] = model
+                mcps = compilable.compile(
+                    sig, detector=detector, models=[model])
+                process.SetPhaseSpace(sig, mcps)
+
+        process.weighting_mode = _resolve_weighting_mode(self.weighting)
+
+        # `self.interactions`/`self.distributions`/`self.kinematics` are the
+        # strong references keeping every Python model, distribution, and
+        # mixture alive for as long as this Vertex is alive (the pybind
+        # process objects above hold no __dict__ of their own to pin
+        # keepalives on -- they are not built with dynamic_attr()). The
+        # compiled process's Python-side trampolines (a DarkNews model, a
+        # custom distribution) therefore survive gc.collect() exactly as
+        # long as the Vertex that compiled them does; callers that want the
+        # process to outlive the Vertex must keep the Vertex around too.
+        return process

--- a/python/vertex.py
+++ b/python/vertex.py
@@ -90,7 +90,7 @@ class Vertex:
         The particle this vertex is compiled for (the primary of the
         root vertex, or the secondary type of a non-root vertex).
     interactions : Decay/CrossSection or list thereof
-        The interaction model(s) driving this vertex.
+        The interaction model(s) used to sample this vertex.
     distributions : list, optional
         PrimaryInjectionDistribution / SecondaryInjectionDistribution
         objects sampling this vertex's free parameters.
@@ -100,6 +100,8 @@ class Vertex:
     physical : list, optional
         Physical-side distributions kept on the Vertex for the Weighter
         to read; not consumed by Vertex.compile() itself.
+    physical_interactions : Decay/CrossSection or non-empty list/tuple, optional
+        Physical model(s) for the Weighter. None means use `interactions`.
     kinematics : channels.Mixture, channels.Channel, _directed.Directed, optional
         Phase-space biasing description, compiled once per signature
         enumerated from `interactions`. None means no phase space is
@@ -129,6 +131,7 @@ class Vertex:
         "interactions",
         "distributions",
         "physical",
+        "physical_interactions",
         "kinematics",
         "weighting",
         "expand",
@@ -137,7 +140,7 @@ class Vertex:
     )
 
     def __init__(self, particle, interactions, *, distributions=None,
-                 position=None, physical=None, kinematics=None,
+                 position=None, physical=None, physical_interactions=None, kinematics=None,
                  weighting=None, expand=(), continue_if=None, label=None):
         self.particle = particle
         self._resolved_particle = _particles.resolve(particle)
@@ -153,6 +156,18 @@ class Vertex:
         self.distributions = dists
 
         self.physical = list(physical) if physical is not None else []
+        self.physical_interactions = (
+            None if physical_interactions is None else _as_list(physical_interactions))
+        if self.physical_interactions is not None:
+            siren = _siren()
+            if not self.physical_interactions or not all(
+                isinstance(model, (siren.interactions.Decay, siren.interactions.CrossSection))
+                for model in self.physical_interactions
+            ):
+                raise ConfigurationError(
+                    "Vertex(particle={!r}): physical_interactions must be a Decay/"
+                    "CrossSection or a non-empty list/tuple thereof; use None to "
+                    "inherit interactions".format(particle))
         self.kinematics = kinematics
         self.weighting = weighting
         self.expand = tuple(expand)

--- a/tests/python/test_channels_algebra.py
+++ b/tests/python/test_channels_algebra.py
@@ -1,0 +1,561 @@
+"""Channel algebra: normalization, name resolution, PairMass, tiling,
+and Mixture.validate() config-time checks.
+
+All tests are data-free: no detector model, no data files. Anything that
+genuinely needs one is skipped with pytest.skip.
+"""
+
+import math
+
+import pytest
+
+siren = pytest.importorskip("siren")
+channels = pytest.importorskip("siren.channels")
+
+
+# ------------------------------------------------------------------ #
+#  Helpers                                                             #
+# ------------------------------------------------------------------ #
+
+
+def _box_at(z, half=1.0):
+    return siren.geometry.Box(
+        siren.geometry.Placement(siren.math.Vector3D(0.0, 0.0, z)),
+        2.0 * half, 2.0 * half, 2.0 * half)
+
+
+def _decay2body_signature():
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.particles.N4
+    sig.target_type = siren.dataclasses.ParticleType.Decay
+    sig.secondary_types = [siren.particles.NuLight, siren.particles.Gamma]
+    return sig
+
+
+def _decay3body_signature():
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.particles.N4
+    sig.target_type = siren.dataclasses.ParticleType.Decay
+    sig.secondary_types = [
+        siren.particles.NuLight, siren.particles.EMinus, siren.particles.EPlus]
+    return sig
+
+
+def _scatter_signature():
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.particles.NuMu
+    sig.target_type = siren.dataclasses.ParticleType.O16Nucleus
+    sig.secondary_types = [siren.particles.NuMu, siren.dataclasses.ParticleType.O16Nucleus]
+    return sig
+
+
+def _scatter_record(bjorken_y=0.3, E=1.0, m_target=14.9):
+    rec = siren.dataclasses.InteractionRecord()
+    rec.signature = _scatter_signature()
+    rec.primary_mass = 0.0
+    rec.primary_momentum = [E, 0.0, 0.0, E]
+    rec.target_mass = m_target
+    rec.secondary_masses = [0.0, m_target]
+    rec.secondary_momenta = [[0.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]]
+    rec.secondary_helicities = [0, 0]
+    rec.interaction_vertex = [0.0, 0.0, 0.0]
+    rec.primary_initial_position = [0.0, 0.0, 0.0]
+    rec.interaction_parameters = {"bjorken_y": bjorken_y}
+    return rec
+
+
+# ------------------------------------------------------------------ #
+#  Normalization by construction                                       #
+# ------------------------------------------------------------------ #
+
+class TestNormalization:
+
+    def test_add_normalizes(self):
+        mix = 0.3 * channels.isotropic() + 0.7 * channels.isotropic("Gamma")
+        weights = [w for w, _ in mix._entries]
+        assert math.isclose(sum(weights), 1.0)
+        assert math.isclose(weights[0], 0.3)
+        assert math.isclose(weights[1], 0.7)
+
+    def test_unnormalized_add_still_normalizes(self):
+        mix = channels.isotropic() * 3.0 + channels.isotropic("Gamma") * 1.0
+        weights = [w for w, _ in mix._entries]
+        assert math.isclose(sum(weights), 1.0)
+        assert math.isclose(weights[0], 0.75)
+        assert math.isclose(weights[1], 0.25)
+
+    def test_three_way_mix_normalizes(self):
+        box = _box_at(50.0)
+        mix = (channels.isotropic()
+               + channels.isotropic("Gamma")
+               + channels.toward("Gamma", box))
+        weights = [w for w, _ in mix._entries]
+        assert len(weights) == 3
+        assert math.isclose(sum(weights), 1.0)
+
+    def test_mixture_plus_channel_renormalizes(self):
+        mix = 0.5 * channels.isotropic() + 0.5 * channels.isotropic("Gamma")
+        mix2 = mix + channels.isotropic()
+        weights = [w for w, _ in mix2._entries]
+        assert len(weights) == 3
+        assert math.isclose(sum(weights), 1.0)
+
+    def test_channel_plus_mixture_renormalizes(self):
+        mix = 0.5 * channels.isotropic() + 0.5 * channels.isotropic("Gamma")
+        mix2 = channels.isotropic() + mix
+        weights = [w for w, _ in mix2._entries]
+        assert len(weights) == 3
+        assert math.isclose(sum(weights), 1.0)
+
+    def test_nested_rescale_composes_scale(self):
+        """`p * (q * mixture)` composes to p*q, not a flat replacement by p.
+
+        The carried composition scale must multiply through nested `*`, matching
+        _MixtureNode's Channel/Tiling behavior; otherwise a double-rescaled
+        mixture silently drops its inner factor.
+        """
+        inner = 0.5 * (channels.isotropic() + channels.isotropic("Gamma"))
+        assert math.isclose(inner._scale, 0.5)
+        outer = 0.6 * inner
+        # The inner 0.5 must survive: 0.6 * 0.5 = 0.3, not 0.6.
+        assert math.isclose(outer._scale, 0.3)
+        assert math.isclose(sum(w for w, _ in outer._scaled_entries()), 0.3)
+
+    def test_empty_mixture_rejected(self):
+        with pytest.raises(siren.utilities.ConfigurationError):
+            channels.Mixture([])
+
+    def test_negative_weight_rejected(self):
+        with pytest.raises(siren.utilities.ConfigurationError):
+            channels.Mixture([(-0.5, channels.isotropic()),
+                               (1.5, channels.isotropic("Gamma"))])
+
+    def test_nonfinite_weight_rejected(self):
+        with pytest.raises(siren.utilities.ConfigurationError):
+            channels.Mixture([(float("nan"), channels.isotropic())])
+        with pytest.raises(siren.utilities.ConfigurationError):
+            channels.Mixture([(float("inf"), channels.isotropic())])
+
+    def test_toward_fraction_mixes_physical_fallback(self):
+        box = _box_at(50.0)
+        mix = channels.toward("Gamma", box, fraction=0.3)
+        assert isinstance(mix, channels.Mixture)
+        weights = sorted(w for w, _ in mix._entries)
+        assert math.isclose(sum(weights), 1.0)
+        assert math.isclose(weights[0], 0.3, abs_tol=1e-9)
+        assert math.isclose(weights[1], 0.7, abs_tol=1e-9)
+
+    def test_toward_fraction_one_is_bare_channel(self):
+        box = _box_at(50.0)
+        result = channels.toward("Gamma", box, fraction=1.0)
+        assert isinstance(result, channels.Channel)
+
+
+# ------------------------------------------------------------------ #
+#  Per-signature name resolution                                       #
+# ------------------------------------------------------------------ #
+
+class TestNameResolution:
+
+    def test_absent_particle_raises_configuration_error(self):
+        sig = _decay2body_signature()
+        ch = channels.isotropic("NotAKnownParticle")
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+    def test_ambiguous_particle_raises_configuration_error(self):
+        sig = siren.dataclasses.InteractionSignature()
+        sig.primary_type = siren.particles.N4
+        sig.target_type = siren.dataclasses.ParticleType.Decay
+        sig.secondary_types = [siren.particles.Gamma, siren.particles.Gamma]
+        ch = channels.isotropic("Gamma")
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+    def test_named_particle_resolves_to_correct_index(self):
+        sig = _decay2body_signature()  # [NuLight, Gamma]
+        box = _box_at(50.0)
+        ch = channels.toward("Gamma", box)
+        built = ch._build(sig)
+        assert isinstance(built, siren.injection.DetectorDirected2BodyChannel)
+
+    def test_integer_daughter_bypasses_resolution(self):
+        sig = _decay2body_signature()
+        ch = channels.isotropic(1)
+        built = ch._build(sig)
+        assert isinstance(built, siren.injection.Isotropic2BodyChannel)
+
+    def test_toward_3body_bad_spectator_name_raises(self):
+        sig = _decay3body_signature()
+        box = _box_at(50.0)
+        ch = channels.toward_3body("EMinus", box, spectator="NotAParticle",
+                                   strategy="recursive")
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+    def test_toward_3body_missing_spectator_raises(self):
+        sig = _decay3body_signature()
+        box = _box_at(50.0)
+        ch = channels.toward_3body("EMinus", box, strategy="recursive")
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+    def test_scatter_toward_named_daughter_resolves_index(self, monkeypatch):
+        """scatter_toward(daughter=...) resolves the named daughter to its
+        secondary index and threads it to the engine channel; the default
+        selects the index-0 secondary."""
+        sig = _scatter_signature()  # secondary_types = [NuMu, O16Nucleus]
+        box = _box_at(50.0)
+        captured = {}
+
+        def _spy(target, directed_index, *args, **kwargs):
+            captured["idx"] = directed_index
+            return "sentinel"
+
+        monkeypatch.setattr(
+            siren.injection, "DetectorDirectedScatteringChannel", _spy)
+
+        channels.scatter_toward(box, daughter="O16Nucleus")._build(sig)
+        assert captured["idx"] == 1
+
+        captured.clear()
+        channels.scatter_toward(box)._build(sig)
+        assert captured["idx"] == 0
+
+    def test_scatter_toward_bad_daughter_name_raises(self):
+        """An unknown daughter name is a loud ConfigurationError, so the
+        parameter genuinely routes through _resolve_index."""
+        sig = _scatter_signature()
+        box = _box_at(50.0)
+        ch = channels.scatter_toward(box, daughter="NotAParticle")
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+
+# ------------------------------------------------------------------ #
+#  PairMass factories map to the right ctor kwargs                     #
+# ------------------------------------------------------------------ #
+
+class TestPairMass:
+
+    def test_uniform(self):
+        pm = channels.PairMass.uniform()
+        assert pm.mass_mode == siren.injection.InvariantMassMode.Uniform
+
+    def test_breit_wigner_fields(self):
+        pm = channels.PairMass.breit_wigner(0.017, 0.001)
+        assert pm.mass_mode == siren.injection.InvariantMassMode.BreitWigner
+        assert pm.resonance_mass == 0.017
+        assert pm.resonance_width == 0.001
+
+    def test_power_law_fields(self):
+        pm = channels.PairMass.power_law(0.6, offset=0.1)
+        assert pm.mass_mode == siren.injection.InvariantMassMode.PowerLaw
+        assert pm.power_law_nu == 0.6
+        assert pm.power_law_offset == 0.1
+
+    def test_tabulated_fields(self):
+        nodes = [0.1, 0.2, 0.3]
+        values = [0.0, 0.5, 1.0]
+        pm = channels.PairMass.tabulated(nodes, values)
+        assert pm.mass_mode == siren.injection.InvariantMassMode.Tabulated
+        assert pm.mass_cdf_nodes == nodes
+        assert pm.mass_cdf_values == values
+
+    def test_breit_wigner_reaches_3body_ctor_direct(self):
+        sig = _decay3body_signature()
+        box = _box_at(50.0)
+        pm = channels.PairMass.breit_wigner(0.017, 0.001)
+        ch = channels.toward_3body("EMinus", box, strategy="direct", pair_mass=pm)
+        built = ch._build(sig)
+        assert isinstance(built, siren.injection.DetectorDirected3BodyChannel)
+        assert built.Topology() == siren.injection.PhaseSpaceTopology.Decay3Body
+
+    def test_power_law_reaches_3body_ctor_recursive(self):
+        sig = _decay3body_signature()
+        box = _box_at(50.0)
+        pm = channels.PairMass.power_law(0.6, offset=0.05)
+        ch = channels.toward_3body("EMinus", box, spectator="NuLight",
+                                   strategy="recursive", pair_mass=pm)
+        built = ch._build(sig)
+        assert isinstance(built, siren.injection.DetectorDirected3BodyChannel)
+        measure = built.Measure()
+        assert measure.type == siren.injection.PhaseSpaceMeasureType.Recursive2Body
+
+
+# ------------------------------------------------------------------ #
+#  tile() disjointness                                                 #
+# ------------------------------------------------------------------ #
+
+class TestTiling:
+
+    def test_tile_returns_tiling(self):
+        box = _box_at(50.0, half=1.0)
+        t = channels.tile(box, 2)
+        assert isinstance(t, channels.Tiling)
+
+    def test_tile_compiles_to_nested_mixture(self):
+        sig = _decay2body_signature()
+        box = _box_at(50.0, half=1.0)
+        t = channels.tile(box, 2)
+        built = t._build(sig)
+        assert isinstance(built, siren.injection.NestedMixtureChannel)
+        # 2x2x2 grid cells, all disjointified (disjointify keeps every tile)
+        assert len(built.mixture.channels) == 8
+
+    def test_tile_cells_are_disjoint(self):
+        # grid_cells() partitions the box into non-overlapping sub-boxes;
+        # sample points and require each falls in exactly one cell.
+        box = siren.geometry.Box(
+            siren.geometry.Placement(siren.math.Vector3D(0.0, 0.0, 0.0)),
+            2.0, 2.0, 2.0)
+        from siren import directed_tiling
+        cells = directed_tiling.grid_cells(box, 2)
+        assert len(cells) == 8
+
+        rng = siren.utilities.SIREN_random(1234)
+        n_checked = 0
+        for _ in range(500):
+            p = siren.math.Vector3D(
+                rng.Uniform(-1.0, 1.0), rng.Uniform(-1.0, 1.0), rng.Uniform(-1.0, 1.0))
+            hits = [c for c in cells if c.IsInside(p)]
+            assert len(hits) <= 1, "point {} landed in {} disjoint cells".format(p, len(hits))
+            if hits:
+                n_checked += 1
+        assert n_checked > 0
+
+    def test_tile_participates_in_mixture_algebra(self):
+        box = _box_at(50.0, half=1.0)
+        t = channels.tile(box, 2)
+        mix = 0.4 * channels.isotropic() + 0.6 * t
+        weights = [w for w, _ in mix._entries]
+        assert math.isclose(sum(weights), 1.0)
+        assert any(isinstance(ch, channels.Tiling) for _, ch in mix._entries)
+
+    def test_tile_rejects_unknown_method(self):
+        box = _box_at(50.0, half=1.0)
+        with pytest.raises(siren.utilities.ConfigurationError):
+            channels.tile(box, 2, method="not-a-method")
+
+    def test_grid_cells_rejects_rotated_box(self):
+        """A rotated Box cannot be tiled with axis-aligned sub-cells: loud.
+
+        The sub-cells are emitted axis-aligned in world coordinates, so a
+        non-identity placement rotation would neither partition nor cover the
+        true (rotated) volume.
+        """
+        from siren import directed_tiling
+        # 90 degrees about z: quaternion (0, 0, sin(pi/4), cos(pi/4)).
+        q = siren.math.Quaternion(0.0, 0.0, math.sin(math.pi / 4),
+                                  math.cos(math.pi / 4))
+        rotated = siren.geometry.Box(
+            siren.geometry.Placement(siren.math.Vector3D(0.0, 0.0, 50.0), q),
+            2.0, 2.0, 2.0)
+        with pytest.raises(siren.utilities.ConfigurationError,
+                           match="axis-aligned"):
+            directed_tiling.grid_cells(rotated, 2)
+
+    def test_grid_cells_rejects_non_box(self):
+        """A non-Box region raises the same ConfigurationError fault class as
+        the rotated-Box rejection, not a bare TypeError."""
+        from siren import directed_tiling
+        sphere = siren.geometry.Sphere(
+            siren.geometry.Placement(siren.math.Vector3D(0.0, 0.0, 50.0)),
+            1.0, 0.0)
+        with pytest.raises(siren.utilities.ConfigurationError, match="Box"):
+            directed_tiling.grid_cells(sphere, 2)
+
+
+# ------------------------------------------------------------------ #
+#  Mixture.validate()                                                  #
+# ------------------------------------------------------------------ #
+
+class TestValidate:
+
+    def test_topology_mismatch_is_fatal(self):
+        """Isotropic2Body (Decay2Body) mixed with a scattering channel
+        (Scatter2to2) is a structural topology mismatch: fatal at
+        construction time, before any ConvertDensity probe runs.
+        """
+        box = _box_at(50.0)
+        iso = channels.isotropic(0)
+        sc = channels.scatter_toward(box)
+
+        # Build engine channels directly to bypass per-signature resolution
+        # differences between the two factories' expected signatures --
+        # the topology mismatch is a property of the channel types
+        # themselves, independent of signature.
+        engine_iso = siren.injection.Isotropic2BodyChannel(0)
+        engine_sc = siren.injection.DetectorDirectedScatteringChannel(box, 0)
+        with pytest.raises(siren.utilities.MeasureCompatibilityError):
+            siren.injection.MultiChannelPhaseSpace(
+                [engine_iso, engine_sc], [0.5, 0.5])
+
+    def test_validate_catches_topology_mismatch_mixture(self):
+        """A Mixture whose Channel factories build engine channels of two
+        different topologies fails Mixture.validate() with
+        MeasureCompatibilityError, surfaced at configuration time.
+        """
+        box = _box_at(50.0)
+
+        def iso_factory(signature, *, detector=None, models=None):
+            return siren.injection.Isotropic2BodyChannel(0)
+
+        def scatter_factory(signature, *, detector=None, models=None):
+            return siren.injection.DetectorDirectedScatteringChannel(box, 0)
+
+        bad_iso = channels.Channel(iso_factory, label="iso")
+        bad_sc = channels.Channel(scatter_factory, label="scatter")
+        mix = 0.5 * bad_iso + 0.5 * bad_sc
+
+        with pytest.raises(siren.utilities.MeasureCompatibilityError):
+            mix.validate(_decay2body_signature())
+
+    def test_validate_passes_for_convertible_mixed_measure_mixture(self):
+        """isotropic (SolidAngleRest) + toward (SolidAngleRest): the same
+        measure, so validate() must not raise.
+        """
+        box = _box_at(50.0)
+        mix = 0.3 * channels.isotropic("Gamma") + 0.7 * channels.toward("Gamma", box)
+        mcps = mix.validate(_decay2body_signature())
+        assert len(mcps.channels) == 2
+
+    def test_validate_passes_for_genuinely_different_convertible_measures(self):
+        """MandelstamQ2Phi (default scatter_toward) mixed with FixedMassYPhi
+        (variable=BjorkenY): genuinely different measures within
+        Scatter2to2, related by an implemented ConvertDensity conversion.
+        validate() must not raise for this combination.
+        """
+        box = _box_at(50.0)
+        q2_chan = channels.scatter_toward(
+            box, variable=siren.injection.ScatteringVariable.Q2)
+        y_chan = channels.scatter_toward(
+            box, variable=siren.injection.ScatteringVariable.BjorkenY)
+        mix = 0.5 * q2_chan + 0.5 * y_chan
+
+        sig = _scatter_signature()
+        mcps = mix.compile(sig)
+        topology = mcps.CommonTopology()
+        common_measure = mcps.CommonMeasure()
+        y = 0.3
+        m_target = 14.9
+        E = 1.0
+        record = _scatter_record(bjorken_y=y, E=E, m_target=m_target)
+        MType = siren.injection.PhaseSpaceMeasureType
+
+        # Q2 = 2*M*E*y + constant at fixed final-state masses, so
+        # |dQ2/dy| = 2*M*E, independent of y. A unit density in y therefore
+        # converts to 1/(2*M*E) in Q2, and a unit Q2 density converts to
+        # 2*M*E in y.
+        abs_jac = 2.0 * m_target * E  # = 29.8 for these kinematics
+        checked = 0
+        for ch in mcps.channels:
+            measure = ch.Measure()
+            if measure == common_measure:
+                continue
+            # This is exactly the conversion validate()'s probe performs.
+            result = siren.injection.ConvertDensity(
+                1.0, measure, common_measure, topology, record)
+            assert math.isfinite(result) and result > 0.0
+            if (measure.type == MType.FixedMassYPhi
+                    and common_measure.type == MType.MandelstamQ2Phi):
+                expected = 1.0 / abs_jac
+            elif (measure.type == MType.MandelstamQ2Phi
+                    and common_measure.type == MType.FixedMassYPhi):
+                expected = abs_jac
+            else:
+                raise AssertionError(
+                    "unexpected measure pair {} -> {}".format(
+                        measure.type, common_measure.type))
+            assert result == pytest.approx(expected, rel=1e-12)
+            checked += 1
+        assert checked >= 1
+
+    def test_validate_returns_compiled_mixture(self):
+        box = _box_at(50.0)
+        mix = 0.3 * channels.isotropic() + 0.7 * channels.toward(0, box)
+        mcps = mix.validate(_decay2body_signature())
+        assert isinstance(mcps, siren.injection.MultiChannelPhaseSpace)
+        assert math.isclose(sum(mcps.weights), 1.0)
+
+    def test_validate_default_template_signature(self):
+        """validate() with no signature argument uses the built-in
+        decay-shaped template signature."""
+        box = _box_at(50.0)
+        mix = 0.3 * channels.isotropic("Gamma") + 0.7 * channels.toward("Gamma", box)
+        mcps = mix.validate()
+        assert len(mcps.channels) == 2
+
+
+# ------------------------------------------------------------------ #
+#  describe()                                                          #
+# ------------------------------------------------------------------ #
+
+class TestDescribe:
+
+    def test_channel_describe(self):
+        assert channels.isotropic().describe() == "isotropic"
+
+    def test_mixture_describe_contains_weights_and_labels(self):
+        mix = 0.3 * channels.isotropic() + 0.7 * channels.isotropic("Gamma")
+        text = mix.describe()
+        assert "0.30" in text
+        assert "0.70" in text
+        assert "isotropic" in text
+        assert "+" in text
+
+
+# ------------------------------------------------------------------ #
+#  physical() late binding                                             #
+# ------------------------------------------------------------------ #
+
+class TestPhysical:
+
+    def test_physical_without_models_raises(self):
+        sig = _scatter_signature()
+        ch = channels.physical()
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig)
+
+    def test_physical_with_multiple_models_raises(self):
+        sig = _scatter_signature()
+        xs = siren.interactions.DummyCrossSection()
+        ch = channels.physical()
+        with pytest.raises(siren.utilities.ConfigurationError):
+            ch._build(sig, models=[xs, xs])
+
+    def test_physical_routes_cross_section(self):
+        sig = _scatter_signature()
+        xs = siren.interactions.DummyCrossSection()
+        ch = channels.physical()
+        built = ch._build(sig, models=[xs])
+        assert isinstance(built, siren.injection.PhysicalCrossSectionChannel)
+
+    def test_physical_compiles_via_mixture(self):
+        sig = _scatter_signature()
+        xs = siren.interactions.DummyCrossSection()
+        mix = channels.Mixture([(1.0, channels.physical())])
+        mcps = mix.compile(sig, models=[xs])
+        assert isinstance(mcps.channels[0], siren.injection.PhysicalCrossSectionChannel)
+
+    def test_physical_validates_via_mixture(self):
+        sig = _scatter_signature()
+        xs = siren.interactions.DummyCrossSection()
+        mix = channels.Mixture([(1.0, channels.physical())])
+        mcps = mix.validate(sig, models=[xs])
+        assert isinstance(mcps.channels[0], siren.injection.PhysicalCrossSectionChannel)
+
+
+class TestCompositionScale:
+
+    def test_scaled_mixture_composition_splits_shares(self):
+        """p * mix_a + q * channel gives each sub-channel its share of the total."""
+        composed = (0.3 * (0.5 * channels.isotropic(0) + 0.5 * channels.isotropic(1))
+                    + 0.7 * channels.isotropic(0))
+        weights = [round(w, 6) for w, _ in composed._entries]
+        assert weights == [0.15, 0.15, 0.7]
+
+    def test_standalone_mixture_stays_normalized(self):
+        """A scaled mixture used on its own is still normalized to sum 1."""
+        mix = 0.3 * (0.5 * channels.isotropic(0) + 0.5 * channels.isotropic(1))
+        assert math.isclose(sum(w for w, _ in mix._entries), 1.0)

--- a/tests/python/test_expand_wiring.py
+++ b/tests/python/test_expand_wiring.py
@@ -1,0 +1,151 @@
+"""Tests for siren.expand vocabulary and expansion-wiring validation."""
+
+import pytest
+
+siren = pytest.importorskip("siren")
+
+from siren import dataclasses as dc
+from siren.expand import child, depth_below, compile_expansion, VertexSpec
+from siren._validation import (
+    validate_expansion_wiring,
+    check_expand_vs_legacy_stopping,
+)
+from siren.errors import ConfigurationError
+
+PT = dc.ParticleType
+
+
+def _make_record(primary_type, secondary_types):
+    rec = dc.InteractionRecord()
+    rec.signature.primary_type = primary_type
+    rec.signature.target_type = PT.Decay
+    rec.signature.secondary_types = list(secondary_types)
+    rec.secondary_masses = [0.0 for _ in secondary_types]
+    rec.secondary_momenta = [[0, 0, 0, 0] for _ in secondary_types]
+    rec.secondary_helicities = [0 for _ in secondary_types]
+    return rec
+
+
+def _tree_with_root(primary_type, secondary_types):
+    """Build a real InteractionTree with one root datum via add_entry."""
+    tree = dc.InteractionTree()
+    rec = _make_record(primary_type, secondary_types)
+    parent = tree.add_entry(rec, None)
+    return tree, parent
+
+
+def test_listed_daughter_expands_unlisted_terminates():
+    """A daughter named in expand continues; an unlisted daughter prunes."""
+    tree, parent = _tree_with_root(PT.N4, [PT.NuLight, PT.Gamma])
+    vertices = [
+        VertexSpec(particle=PT.N4, expand=(child("NuLight"),), continue_if=None),
+    ]
+    stopping_condition = compile_expansion(vertices)
+
+    assert stopping_condition(tree, parent, 0) is False
+    assert stopping_condition(tree, parent, 1) is True
+
+
+def test_child_index_restricts_match():
+    """child(index=0) expands only the secondary at position 0."""
+    tree, parent = _tree_with_root(PT.NuLight, [PT.NuLight, PT.NuLight])
+    vertices = [
+        VertexSpec(
+            particle=PT.NuLight,
+            expand=(child("NuLight", index=0),),
+            continue_if=None,
+        ),
+    ]
+    stopping_condition = compile_expansion(vertices)
+
+    assert stopping_condition(tree, parent, 0) is False
+    assert stopping_condition(tree, parent, 1) is True
+
+
+def test_depth_below_expands_while_shallow():
+    """depth_below(n) expands while parent depth < n, prunes at depth >= n."""
+    tree, shallow_parent = _tree_with_root(PT.N4, [PT.NuLight])
+    assert shallow_parent.depth(tree) == 0
+
+    grandchild_rec = _make_record(PT.NuLight, [PT.NuLight])
+    deep_parent = tree.add_entry(grandchild_rec, shallow_parent)
+    assert deep_parent.depth(tree) == 1
+
+    vertices = [
+        VertexSpec(particle=PT.N4, expand=(depth_below(1),), continue_if=None),
+        VertexSpec(particle=PT.NuLight, expand=(depth_below(1),), continue_if=None),
+    ]
+    stopping_condition = compile_expansion(vertices)
+
+    assert stopping_condition(tree, shallow_parent, 0) is False
+    assert stopping_condition(tree, deep_parent, 0) is True
+
+
+def test_continue_if_can_veto_a_matched_child():
+    """A matched child rule still prunes when continue_if returns False."""
+    tree, parent = _tree_with_root(PT.N4, [PT.NuLight])
+    vertices = [
+        VertexSpec(
+            particle=PT.N4,
+            expand=(child("NuLight"),),
+            continue_if=lambda tree, parent, i: False,
+        ),
+    ]
+    stopping_condition = compile_expansion(vertices)
+
+    assert stopping_condition(tree, parent, 0) is True
+
+
+def test_unregistered_parent_type_prunes():
+    """A parent whose primary_type has no registered vertex always prunes."""
+    tree, parent = _tree_with_root(PT.MuMinus, [PT.NuLight])
+    vertices = [
+        VertexSpec(particle=PT.N4, expand=(child("NuLight"),), continue_if=None),
+    ]
+    stopping_condition = compile_expansion(vertices)
+
+    assert stopping_condition(tree, parent, 0) is True
+
+
+def test_wiring_error_unregistered_child_target():
+    """expand names a particle with no registered Vertex -> ConfigurationError."""
+    vertices = [
+        VertexSpec(particle=PT.N4, expand=(child("NuLight"),), continue_if=None),
+    ]
+    with pytest.raises(ConfigurationError):
+        validate_expansion_wiring(vertices)
+
+
+def test_wiring_error_unreachable_vertex():
+    """A registered Vertex named by no expand list -> ConfigurationError."""
+    vertices = [
+        VertexSpec(particle=PT.N4, expand=(), continue_if=None),
+        VertexSpec(particle=PT.NuLight, expand=(), continue_if=None),
+    ]
+    with pytest.raises(ConfigurationError):
+        validate_expansion_wiring(vertices)
+
+
+def test_wiring_error_secondaries_without_expansion():
+    """Secondaries present but no expand declaration at all -> ConfigurationError."""
+    vertices = [
+        VertexSpec(
+            particle=PT.N4,
+            expand=(),
+            continue_if=None,
+            secondary_types=[PT.NuLight, PT.Gamma],
+        ),
+    ]
+    with pytest.raises(ConfigurationError):
+        validate_expansion_wiring(vertices)
+
+
+def test_legacy_stopping_condition_with_expand_is_hard_error():
+    """Legacy stopping_condition plus expand/continue_if -> ConfigurationError."""
+    with pytest.raises(ConfigurationError):
+        check_expand_vs_legacy_stopping(True, True)
+
+    # Either alone is fine.
+    check_expand_vs_legacy_stopping(True, False)
+    check_expand_vs_legacy_stopping(False, True)
+    check_expand_vs_legacy_stopping(False, False)

--- a/tests/python/test_vertex_spec.py
+++ b/tests/python/test_vertex_spec.py
@@ -1,0 +1,401 @@
+"""Vertex.compile() parity with hand-built processes, and Directed sugar.
+
+All tests are data-free: no detector model, no data files. Anything that
+genuinely needs one is skipped with pytest.skip.
+"""
+
+import gc
+import math
+
+import pytest
+
+siren = pytest.importorskip("siren")
+vertex = pytest.importorskip("siren.vertex")
+directed_mod = pytest.importorskip("siren._directed")
+channels = pytest.importorskip("siren.channels")
+
+Vertex = vertex.Vertex
+Directed = directed_mod.Directed
+
+
+# ------------------------------------------------------------------ #
+#  Helpers                                                             #
+# ------------------------------------------------------------------ #
+
+def _box_at(z, half=1.0):
+    return siren.geometry.Box(
+        siren.geometry.Placement(siren.math.Vector3D(0.0, 0.0, z)),
+        2.0 * half, 2.0 * half, 2.0 * half)
+
+
+def _dummy_xs():
+    return siren.interactions.DummyCrossSection()
+
+
+def _decay2body_signature():
+    sig = siren.dataclasses.InteractionSignature()
+    sig.primary_type = siren.particles.N4
+    sig.target_type = siren.dataclasses.ParticleType.Decay
+    sig.secondary_types = [siren.particles.NuLight, siren.particles.Gamma]
+    return sig
+
+
+class _KeepAliveCrossSection(siren.interactions.CrossSection):
+    """Data-free Python-subclassed CrossSection, instrumented for gc checks."""
+
+    alive_count = 0
+
+    def __init__(self):
+        siren.interactions.CrossSection.__init__(self)
+        _KeepAliveCrossSection.alive_count += 1
+
+    def __del__(self):
+        _KeepAliveCrossSection.alive_count -= 1
+
+    def TotalCrossSection(self, *args, **kwargs):
+        return 1.0
+
+    def DifferentialCrossSection(self, *args):
+        return 1.0
+
+    def InteractionThreshold(self, *args):
+        return 0.0
+
+    def SampleFinalState(self, *args):
+        pass
+
+    def GetPossibleTargets(self):
+        return [siren.particles.Nucleon]
+
+    def GetPossibleTargetsFromPrimary(self, primary_type):
+        return [siren.particles.Nucleon]
+
+    def GetPossiblePrimaries(self):
+        return [siren.particles.NuMu]
+
+    def GetPossibleSignatures(self):
+        sig = siren.dataclasses.InteractionSignature()
+        sig.primary_type = siren.particles.NuMu
+        sig.target_type = siren.particles.Nucleon
+        sig.secondary_types = [siren.particles.NuMu, siren.particles.Nucleon]
+        return [sig]
+
+    def GetPossibleSignaturesFromParents(self, primary_type, target_type):
+        return self.GetPossibleSignatures()
+
+    def FinalStateProbability(self, *args):
+        return 1.0
+
+    def DensityVariables(self):
+        return []
+
+    def equal(self, other):
+        return isinstance(other, _KeepAliveCrossSection)
+
+
+# ------------------------------------------------------------------ #
+#  Vertex.compile() parity with a hand-built process                   #
+# ------------------------------------------------------------------ #
+
+class TestVertexCompileParity:
+
+    def test_primary_process_fields_match_hand_built(self):
+        """Vertex.compile(is_primary=True) matches a hand-built PrimaryInjectionProcess."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        dists = [siren.distributions.PrimaryMass(0)]
+
+        v = Vertex(sig.primary_type, xs, distributions=dists)
+        proc = v.compile(is_primary=True)
+
+        assert isinstance(proc, siren.injection.PrimaryInjectionProcess)
+        assert proc.primary_type == sig.primary_type
+        assert list(proc.interactions.GetCrossSections()) == [xs]
+        assert list(proc.distributions) == dists
+
+    def test_secondary_process_fields_match_hand_built(self):
+        """Vertex.compile(is_primary=False) matches a hand-built SecondaryInjectionProcess."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        dists = [siren.distributions.SecondaryPhysicalVertexDistribution()]
+
+        v = Vertex(sig.primary_type, xs, distributions=dists)
+        proc = v.compile(is_primary=False)
+
+        assert isinstance(proc, siren.injection.SecondaryInjectionProcess)
+        assert proc.secondary_type == sig.primary_type
+        assert list(proc.interactions.GetCrossSections()) == [xs]
+        assert list(proc.distributions) == dists
+
+    def test_kinematics_registers_phase_space_for_each_signature(self):
+        """A phase space is registered for every signature the model can produce."""
+        xs = _dummy_xs()
+        sigs = xs.GetPossibleSignatures()
+        v = Vertex(sigs[0].primary_type, xs, distributions=[],
+                   kinematics=channels.isotropic(0))
+
+        # A phase space is registered for each signature sharing this Vertex's
+        # primary_type (InteractionCollection resolves by primary_type).
+        matching = [s for s in sigs if s.primary_type == sigs[0].primary_type]
+        proc = v.compile(is_primary=True)
+        for sig in matching:
+            assert proc.HasPhaseSpace(sig)
+            ps = proc.GetPhaseSpace(sig)
+            assert isinstance(ps, siren.injection.MultiChannelPhaseSpace)
+
+    def test_no_kinematics_registers_no_phase_space(self):
+        """kinematics=None leaves the process with no registered phase space."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        v = Vertex(sig.primary_type, xs, distributions=[])
+        proc = v.compile(is_primary=True)
+        assert not proc.HasAnyPhaseSpace()
+
+    def test_colliding_signature_models_raise(self):
+        """Two models producing the same signature is loud, not a silent drop.
+
+        With kinematics set, each model registers its own phase space under the
+        shared signature; the second would silently replace the first even
+        though InteractionCollection still selects both.
+        """
+        xs_a = _dummy_xs()
+        xs_b = _dummy_xs()
+        # Both DummyCrossSection instances produce the identical signature.
+        assert xs_a.GetPossibleSignatures()[0] == xs_b.GetPossibleSignatures()[0]
+        v = Vertex(xs_a.GetPossibleSignatures()[0].primary_type,
+                   [xs_a, xs_b], distributions=[],
+                   kinematics=channels.isotropic(0))
+        with pytest.raises(siren.utilities.ConfigurationError,
+                           match="produce signature"):
+            v.compile(is_primary=True)
+
+    def test_position_appended_to_distributions(self):
+        """position= is appended to the distributions list, not silently dropped."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        mass = siren.distributions.PrimaryMass(0)
+        pos = siren.distributions.PointSourcePositionDistribution(
+            siren.math.Vector3D(0, 0, 0), 25.0)
+
+        v = Vertex(sig.primary_type, xs, distributions=[mass], position=pos)
+        assert v.distributions == [mass, pos]
+        proc = v.compile(is_primary=True)
+        assert list(proc.distributions) == [mass, pos]
+
+    def test_unknown_kwarg_raises_type_error(self):
+        """A typo'd keyword argument is rejected, not silently ignored."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        with pytest.raises(TypeError):
+            Vertex(sig.primary_type, xs, distirbutions=[])
+
+    def test_unknown_attribute_assignment_raises_attribute_error(self):
+        """__slots__ makes an unrecognized field name unrepresentable."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        v = Vertex(sig.primary_type, xs, distributions=[])
+        with pytest.raises(AttributeError):
+            v.distirbutions = []
+
+
+# ------------------------------------------------------------------ #
+#  Fixed weighting mode reaches the engine                             #
+# ------------------------------------------------------------------ #
+
+class TestWeightingMode:
+
+    def test_fixed_weighting_mode_reaches_process(self):
+        """weighting=Fixed() compiles to compute_interaction_probability=False."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        fixed = siren.injection.VertexWeightingMode.Fixed()
+
+        v = Vertex(sig.primary_type, xs, distributions=[], weighting=fixed)
+        proc = v.compile(is_primary=True)
+
+        assert proc.weighting_mode.compute_interaction_probability == False
+        assert proc.weighting_mode.compute_position_probability == False
+
+    def test_default_weighting_mode_is_propagated(self):
+        """No weighting= given compiles to the Propagated() preset."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        v = Vertex(sig.primary_type, xs, distributions=[])
+        proc = v.compile(is_primary=True)
+        propagated = siren.injection.VertexWeightingMode.Propagated()
+        assert proc.weighting_mode == propagated
+
+
+# ------------------------------------------------------------------ #
+#  Strong refs survive gc.collect()                                    #
+# ------------------------------------------------------------------ #
+
+class TestStrongRefs:
+
+    def test_python_model_survives_gc_after_compile(self):
+        """A Python-subclassed model outlives gc.collect() while its Vertex is alive."""
+        def build():
+            xs = _KeepAliveCrossSection()
+            v = Vertex(siren.particles.NuMu, xs, distributions=[])
+            proc = v.compile(is_primary=True)
+            return v, proc
+
+        before = _KeepAliveCrossSection.alive_count
+        v, proc = build()
+        gc.collect()
+
+        assert _KeepAliveCrossSection.alive_count == before + 1
+        # The compiled process must still be able to reach the model: this
+        # is the load-bearing claim (the local `xs` in build() is long out
+        # of scope, so only the Vertex's own strong ref keeps it callable).
+        recovered = proc.interactions.GetCrossSections()[0]
+        assert recovered.GetPossibleSignatures()[0].primary_type == siren.particles.NuMu
+        assert v.interactions[0] is recovered
+
+    def test_vertex_retains_models_and_distributions_after_compile(self):
+        """The Vertex keeps its own strong refs to models/distributions/kinematics."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        dists = [siren.distributions.PrimaryMass(0)]
+        mix = channels.isotropic(0)
+
+        v = Vertex(sig.primary_type, xs, distributions=dists, kinematics=mix)
+        v.compile(is_primary=True)
+        gc.collect()
+
+        assert v.interactions == [xs]
+        assert v.distributions == dists
+        assert v.kinematics is mix
+
+
+# ------------------------------------------------------------------ #
+#  as_vertex_spec()                                                    #
+# ------------------------------------------------------------------ #
+
+class TestVertexSpec:
+
+    def test_as_vertex_spec_carries_particle_expand_continue_if(self):
+        """as_vertex_spec() exposes particle/expand/continue_if for compile_expansion."""
+        from siren import expand as expand_mod
+
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        rule = expand_mod.child("Nucleon")
+        cont = lambda tree, parent, i: True
+
+        v = Vertex(sig.primary_type, xs, distributions=[],
+                   expand=(rule,), continue_if=cont)
+        spec = v.as_vertex_spec()
+
+        assert spec.particle == sig.primary_type
+        assert spec.expand == (rule,)
+        assert spec.continue_if is cont
+        assert sig.primary_type in spec.secondary_types
+        assert siren.particles.Nucleon in spec.secondary_types
+
+
+# ------------------------------------------------------------------ #
+#  Directed sugar over channels.py                                     #
+# ------------------------------------------------------------------ #
+
+class TestDirected:
+
+    def test_to_mixture_produces_directed_and_fallback_split(self):
+        """Directed(...).to_mixture() mixes the directed term and physical() fallback."""
+        box = _box_at(50.0)
+        d = Directed("Gamma", box, fraction=0.8)
+        mix = d.to_mixture()
+
+        assert isinstance(mix, channels.Mixture)
+        weights = sorted(w for w, _ in mix._entries)
+        assert math.isclose(weights[0], 0.2, abs_tol=1e-9)
+        assert math.isclose(weights[1], 0.8, abs_tol=1e-9)
+
+        desc = mix.describe()
+        assert "toward" in desc
+        assert "physical" in desc
+
+    def test_default_fraction_is_098(self):
+        """Directed's own default fraction is 0.98, distinct from Simulation's 0.99 default."""
+        box = _box_at(50.0)
+        d = Directed("Gamma", box)
+        assert d.fraction == 0.98
+
+    def test_fraction_one_has_no_fallback_term(self):
+        """fraction=1.0 drops the fallback term from the mixture entirely."""
+        box = _box_at(50.0)
+        d = Directed("Gamma", box, fraction=1.0)
+        mix = d.to_mixture()
+        assert len(mix._entries) == 1
+
+    def test_out_of_range_fraction_raises_configuration_error(self):
+        """A fraction outside [0, 1] is rejected at construction time."""
+        box = _box_at(50.0)
+        with pytest.raises(siren.utilities.ConfigurationError):
+            Directed("Gamma", box, fraction=1.5)
+
+    def test_toward_channel_builds_against_decay_signature(self):
+        """The directed term resolves to a DetectorDirected2BodyChannel for a decay signature."""
+        sig = _decay2body_signature()
+        box = _box_at(50.0)
+        # fraction=1.0 drops the physical() fallback, which needs a model to
+        # late-bind against and is not the point of this test.
+        d = Directed("Gamma", box, fraction=1.0)
+        mix = d.to_mixture(sig)
+        engine_channels, weights = mix._flatten(sig)
+        kinds = [type(ch).__name__ for ch in engine_channels]
+        assert "DetectorDirected2BodyChannel" in kinds
+
+    def test_by_signature_maps_to_different_mixtures(self):
+        """Directed.by_signature() dispatches a distinct mixture per signature."""
+        sig_a = _decay2body_signature()
+        sig_b = siren.dataclasses.InteractionSignature()
+        sig_b.primary_type = siren.particles.N4
+        sig_b.target_type = siren.dataclasses.ParticleType.Decay
+        sig_b.secondary_types = [siren.particles.NuLight, siren.particles.EMinus,
+                                  siren.particles.EPlus]
+
+        box = _box_at(50.0)
+        iso_mixture = channels.Mixture([(1.0, channels.isotropic(0))])
+        by_sig = Directed.by_signature({
+            sig_a: Directed("Gamma", box, fraction=0.9),
+            sig_b: iso_mixture,
+        })
+
+        mix_a = by_sig.to_mixture(sig_a)
+        mix_b = by_sig.to_mixture(sig_b)
+
+        assert isinstance(mix_a, channels.Mixture)
+        assert isinstance(mix_b, channels.Mixture)
+        weights_a = sorted(w for w, _ in mix_a._entries)
+        assert math.isclose(weights_a[1], 0.9, abs_tol=1e-9)
+        assert mix_b is iso_mixture
+
+    def test_by_signature_unknown_signature_raises_configuration_error(self):
+        """Looking up a signature absent from the mapping is a ConfigurationError."""
+        sig_a = _decay2body_signature()
+        sig_b = siren.dataclasses.InteractionSignature()
+        sig_b.primary_type = siren.particles.N4
+        sig_b.target_type = siren.dataclasses.ParticleType.Decay
+        sig_b.secondary_types = [siren.particles.NuLight, siren.particles.Gamma,
+                                  siren.particles.Gamma]
+
+        box = _box_at(50.0)
+        by_sig = Directed.by_signature({sig_a: Directed("Gamma", box)})
+        with pytest.raises(siren.utilities.ConfigurationError):
+            by_sig.to_mixture(sig_b)
+
+    def test_vertex_kinematics_accepts_directed(self):
+        """A Vertex's kinematics= accepts a Directed interchangeably with a Mixture."""
+        xs = _dummy_xs()
+        sig = xs.GetPossibleSignatures()[0]
+        # DummyCrossSection's signature is a Scatter2to2 topology, so the
+        # directed term must be scatter_toward() (variable= selects it),
+        # not the default 2-body decay toward(); fraction=1.0 drops the
+        # physical() fallback, which needs a model to late-bind against.
+        d = Directed(sig.secondary_types[0], _box_at(2.0), fraction=1.0,
+                     variable=siren.injection.ScatteringVariable.Q2)
+
+        v = Vertex(sig.primary_type, xs, distributions=[], kinematics=d)
+        proc = v.compile(is_primary=True)
+        assert proc.HasPhaseSpace(sig)

--- a/tests/python/test_vertex_spec.py
+++ b/tests/python/test_vertex_spec.py
@@ -6,6 +6,8 @@ genuinely needs one is skipped with pytest.skip.
 
 import gc
 import math
+import pickle
+import weakref
 
 import pytest
 
@@ -51,6 +53,10 @@ class _KeepAliveCrossSection(siren.interactions.CrossSection):
 
     def __del__(self):
         _KeepAliveCrossSection.alive_count -= 1
+
+    def __reduce__(self):
+        # This test model has no parameters; reconstructing its type suffices.
+        return type(self), ()
 
     def TotalCrossSection(self, *args, **kwargs):
         return 1.0
@@ -196,6 +202,84 @@ class TestVertexCompileParity:
         v = Vertex(sig.primary_type, xs, distributions=[])
         with pytest.raises(AttributeError):
             v.distirbutions = []
+
+
+# ------------------------------------------------------------------ #
+#  Physical interaction declarations                                  #
+# ------------------------------------------------------------------ #
+
+class TestPhysicalInteractions:
+
+    @pytest.mark.parametrize("kwargs", [{}, {"physical_interactions": None}])
+    def test_default_defers_to_sampling_interactions(self, kwargs):
+        proposal = _dummy_xs()
+        v = Vertex(siren.particles.NuMu, proposal, **kwargs)
+        assert v.physical_interactions is None
+        assert v.compile(is_primary=True).interactions.GetCrossSections()[0] is proposal
+
+    @pytest.mark.parametrize("container", [None, list, tuple], ids=["single", "list", "tuple"])
+    @pytest.mark.parametrize("model_type", [siren.interactions.DummyCrossSection,
+                                           siren.interactions.Decay], ids=["scatter", "decay"])
+    def test_normalizes_models_without_aliasing_the_input_list(self, container, model_type):
+        physical = model_type()
+        supplied = physical if container is None else container([physical])
+        v = Vertex(siren.particles.NuMu, _dummy_xs(), physical_interactions=supplied)
+        assert isinstance(v.physical_interactions, list)
+        assert len(v.physical_interactions) == 1
+        assert v.physical_interactions[0] is physical
+        if isinstance(supplied, list):
+            supplied.clear()
+            assert v.physical_interactions == [physical]
+
+    @pytest.mark.parametrize("invalid", [[], (), 1.0, "model", [None], {}])
+    def test_invalid_declarations_raise_configuration_error(self, invalid):
+        with pytest.raises(siren.utilities.ConfigurationError, match="physical_interactions"):
+            Vertex(siren.particles.NuMu, _dummy_xs(), physical_interactions=invalid)
+
+    @pytest.mark.parametrize("is_primary", [True, False], ids=["primary", "secondary"])
+    def test_compile_and_expansion_use_only_sampling_models(self, is_primary):
+        class PhysicalOnly(_KeepAliveCrossSection):
+            def GetPossibleSignatures(self):
+                raise AssertionError("Injection must not inspect physical-only signatures")
+
+        proposal = _dummy_xs()
+        physical = PhysicalOnly()
+        baseline = Vertex(siren.particles.NuMu, proposal, kinematics=channels.isotropic(0))
+        v = Vertex(siren.particles.NuMu, proposal, physical_interactions=physical,
+                   kinematics=channels.isotropic(0))
+        proc = v.compile(is_primary=is_primary)
+        assert len(proc.interactions.GetCrossSections()) == 1
+        assert proc.interactions.GetCrossSections()[0] is proposal
+        assert v.as_vertex_spec().secondary_types == baseline.as_vertex_spec().secondary_types
+        for signature in proposal.GetPossibleSignatures():
+            assert proc.HasPhaseSpace(signature)
+        assert v.physical_interactions[0] is physical
+
+    def test_vertex_owns_physical_model_lifetime(self):
+        physical = _KeepAliveCrossSection()
+        reference = weakref.ref(physical)
+        v = Vertex(siren.particles.NuMu, _dummy_xs(), physical_interactions=physical)
+        proc = v.compile(is_primary=True)
+        del physical
+        gc.collect()
+        assert reference() is v.physical_interactions[0]
+        assert reference().TotalCrossSection(None) == 1.0
+        del v
+        gc.collect()
+        assert reference() is None
+        # Retaining the injection process must not retain a physical-only model.
+        assert len(proc.interactions.GetCrossSections()) == 1
+
+    @pytest.mark.parametrize("explicit", [False, True], ids=["default", "explicit"])
+    def test_pickle_preserves_physical_interaction_declaration(self, explicit):
+        physical = [_KeepAliveCrossSection(), _KeepAliveCrossSection()] if explicit else None
+        v = Vertex(siren.particles.NuMu, _KeepAliveCrossSection(), physical_interactions=physical)
+        restored = pickle.loads(pickle.dumps(v))
+        assert restored.physical_interactions == physical
+        if explicit:
+            assert len(restored.physical_interactions) == 2
+            assert restored.physical_interactions[0] is not restored.interactions[0]
+            assert restored.physical_interactions[0] is not restored.physical_interactions[1]
 
 
 # ------------------------------------------------------------------ #


### PR DESCRIPTION
This PR adds the Layer-2 spec vocabulary as a set of standalone modules:
errors.py's typed exception surface, channels.py's Mixture algebra of
PhaseSpaceChannels (with scale-preserving composition, configuration-time
validation, keyword-native engine construction, per-signature 3-body
topology inference, and a scatter_toward daughter= selector) alongside
directed_tiling.py's disjoint partitions, expand.py's
child()/depth_below() expansion rules and the wiring checks in
_validation.py, vertex.py's Vertex compiler for one chain node, and
_directed.py's Directed sugar for a directed-plus-fallback mix, together
with the test_channels_algebra.py, test_expand_wiring.py, and
test_vertex_spec.py suites covering them.

At this PR's boundary: the build is green; pytest 687 passed, 25 skipped, 14 warnings; the golden archive is byte-identical.

Supersedes part of #164 (`pr/spec-vocabulary`); pre-rewrite history is preserved at tag `archive/v1/spec-vocabulary`.

Note: this branch's history was consolidated a second time after review began; line-anchored review comments (from either round) may reference superseded line numbers.
