### PR TITLE
Rework the Layer-2 Injector and Weighter around generate() and explain()

### DIFF
--- a/projects/geometry/private/pybindings/geometry.cxx
+++ b/projects/geometry/private/pybindings/geometry.cxx
@@ -1,4 +1,5 @@
 
+#include <array>
 #include <vector>
 
 #include "../../public/SIREN/geometry/Placement.h"
@@ -92,7 +93,21 @@ PYBIND11_MODULE(geometry,m) {
 
     class_<Box, std::shared_ptr<Box>, Geometry>(m, "Box")
         .def(init<>())
-        .def(init<double, double, double>())
+        // Positional Box(x, y, z) places the box at the ORIGIN, which reads as
+        // a size-only constructor and silently drops the intended center. Warn
+        // and keep the origin placement rather than raising, so positional
+        // callers are not broken immediately.
+        .def(init([](double x, double y, double z) {
+            PyErr_WarnEx(PyExc_DeprecationWarning,
+                "Box(x, y, z) places the box at the ORIGIN; pass "
+                "Box(widths=(x, y, z), center=(cx, cy, cz))",
+                1);
+            return std::make_shared<Box>(x, y, z);
+        }))
+        .def(init([](std::array<double, 3> widths, std::array<double, 3> center) {
+            Placement placement(siren::math::Vector3D(center[0], center[1], center[2]));
+            return std::make_shared<Box>(placement, widths[0], widths[1], widths[2]);
+        }), arg("widths"), arg("center") = std::array<double, 3>{0.0, 0.0, 0.0})
         .def(init<Placement const &>())
         .def(init<Placement const &, double, double, double>())
         .def(init<const Box&>())

--- a/projects/injection/private/Weighter.cxx
+++ b/projects/injection/private/Weighter.cxx
@@ -116,6 +116,29 @@ void Weighter::Initialize() {
     }
 }
 
+// Fills the observation-only channel_densities and cancelled fields. The
+// per-channel generation densities come from the injection process's mixture
+// for this signature (empty when the vertex has no phase space); cancelled
+// lists the shared distributions removed from both sides of the weight ratio.
+// Never consumed by the weight itself.
+template<typename ProcessPtr>
+static void RecordMixtureDiagnostics(VertexWeightFactors & factors,
+        ProcessPtr const & inj_process,
+        std::vector<std::string> const & cancelled_names,
+        siren::dataclasses::InteractionRecord const & record,
+        std::shared_ptr<siren::detector::DetectorModel> const & detector_model) {
+    factors.cancelled = cancelled_names;
+    if(inj_process && inj_process->HasPhaseSpace(record.signature)) {
+        auto ps = inj_process->GetPhaseSpace(record.signature);
+        factors.channel_density_topology = ps->CommonTopology();
+        factors.channel_density_measure = ps->CommonMeasure();
+        std::vector<double> contributions = ps->DensityBreakdown(detector_model, record);
+        for(std::size_t c = 0; c < contributions.size(); ++c) {
+            factors.channel_densities["channel[" + std::to_string(c) + "]"] = contributions[c];
+        }
+    }
+}
+
 // Computes one tree datum's physical and generation factors for injector idx,
 // via the same ProcessWeighter calls EventWeight consumes. depth is left at
 // its default for non-root data; the caller fills it in from the owning tree.
@@ -135,6 +158,10 @@ VertexWeightFactors Weighter::ComputeVertexFactors(unsigned int idx,
         if(with_diagnostics) {
             factors.interaction_prob = primary_process_weighters[idx]->InteractionProbability(bounds, datum->record);
             factors.position_prob = primary_process_weighters[idx]->NormalizedPositionProbability(bounds, datum->record);
+            RecordMixtureDiagnostics(factors,
+                injectors[idx]->GetPrimaryProcess(),
+                primary_process_weighters[idx]->GetCancelledDistributionNames(),
+                datum->record, detector_model);
         }
     } else {
         try {
@@ -145,6 +172,10 @@ VertexWeightFactors Weighter::ComputeVertexFactors(unsigned int idx,
             if(with_diagnostics) {
                 factors.interaction_prob = w->InteractionProbability(bounds, datum->record);
                 factors.position_prob = w->NormalizedPositionProbability(bounds, datum->record);
+                RecordMixtureDiagnostics(factors,
+                    injectors[idx]->GetSecondaryProcessMap().at(datum->record.signature.primary_type),
+                    w->GetCancelledDistributionNames(),
+                    datum->record, detector_model);
             }
         } catch(const std::out_of_range& oor) {
             std::ostringstream oss;

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -827,6 +827,8 @@ PYBIND11_MODULE(injection,m) {
     .def_readonly("physical", &VertexWeightFactors::physical)
     .def_readonly("interaction_prob", &VertexWeightFactors::interaction_prob)
     .def_readonly("position_prob", &VertexWeightFactors::position_prob)
+    .def_readonly("channel_density_topology", &VertexWeightFactors::channel_density_topology)
+    .def_readonly("channel_density_measure", &VertexWeightFactors::channel_density_measure)
     .def_readonly("channel_densities", &VertexWeightFactors::channel_densities)
     .def_readonly("cancelled", &VertexWeightFactors::cancelled)
     .def_readonly("flags", &VertexWeightFactors::flags);

--- a/projects/injection/private/pybindings/injection.cxx
+++ b/projects/injection/private/pybindings/injection.cxx
@@ -828,6 +828,8 @@ PYBIND11_MODULE(injection,m) {
     .def_readonly("physical", &VertexWeightFactors::physical)
     .def_readonly("interaction_prob", &VertexWeightFactors::interaction_prob)
     .def_readonly("position_prob", &VertexWeightFactors::position_prob)
+    .def_readonly("channel_density_topology", &VertexWeightFactors::channel_density_topology)
+    .def_readonly("channel_density_measure", &VertexWeightFactors::channel_density_measure)
     .def_readonly("channel_densities", &VertexWeightFactors::channel_densities)
     .def_readonly("cancelled", &VertexWeightFactors::cancelled)
     .def_readonly("flags", &VertexWeightFactors::flags);

--- a/projects/injection/public/SIREN/injection/Weighter.h
+++ b/projects/injection/public/SIREN/injection/Weighter.h
@@ -46,6 +46,10 @@ private:
     std::shared_ptr<ProcessType> inj_process;
     std::vector<std::shared_ptr<typename ProcessType::InjectionType>> unique_gen_distributions;
     std::vector<std::shared_ptr<siren::distributions::WeightableDistribution>> unique_phys_distributions;
+    // Names of the injection/physical distributions that matched by operator==
+    // and were removed from both unique_* sets because they cancel in the weight
+    // ratio. Observation-only; recorded once at Initialize().
+    std::vector<std::string> cancelled_distribution_names;
     std::shared_ptr<siren::detector::DetectorModel> detector_model;
     std::vector<std::shared_ptr<typename ProcessType::InjectionType>> const & GetInjectionDistributions();
     void Initialize();
@@ -66,6 +70,8 @@ public:
     double PhysicalProbability(std::tuple<siren::math::Vector3D, siren::math::Vector3D> const & bounds, siren::dataclasses::InteractionRecord const & record) const;
     double GenerationProbability(siren::dataclasses::InteractionTreeDatum const & datum) const;
     double EventWeight(std::tuple<siren::math::Vector3D, siren::math::Vector3D> const & bounds, siren::dataclasses::InteractionTreeDatum const & datum) const;
+    std::vector<std::string> const & GetCancelledDistributionNames() const { return cancelled_distribution_names; }
+    std::shared_ptr<ProcessType> GetInjectionProcess() const { return inj_process; }
     ProcessWeighter(std::shared_ptr<siren::injection::PhysicalProcess> phys_process, std::shared_ptr<ProcessType> inj_process, std::shared_ptr<siren::detector::DetectorModel> detector_model);
 
 }; // ProcessWeighter
@@ -85,6 +91,13 @@ struct VertexWeightFactors {
     double physical = 1.0;
     double interaction_prob = 1.0;
     double position_prob = 1.0;
+    // Convention shared by every value in channel_densities, stored here as
+    // separate topology/measure fields rather than a single
+    // PhaseSpaceConvention.
+    siren::dataclasses::PhaseSpaceTopology channel_density_topology =
+        siren::dataclasses::PhaseSpaceTopology::Unspecified;
+    siren::dataclasses::PhaseSpaceMeasure channel_density_measure =
+        siren::dataclasses::PhaseSpaceMeasure::Unspecified();
     std::map<std::string, double> channel_densities;
     std::vector<std::string> cancelled;
     std::vector<std::string> flags;

--- a/projects/injection/public/SIREN/injection/Weighter.tcc
+++ b/projects/injection/public/SIREN/injection/Weighter.tcc
@@ -82,11 +82,13 @@ void ProcessWeighter<ProcessType>::Initialize() {
     }
     unique_gen_distributions = GetInjectionDistributions();
     unique_phys_distributions = phys_process->GetPhysicalDistributions();
+    cancelled_distribution_names.clear();
     for(typename std::vector<std::shared_ptr<typename ProcessType::InjectionType>>::reverse_iterator gen_it = unique_gen_distributions.rbegin();
             gen_it != unique_gen_distributions.rend(); ++gen_it) {
         for(std::vector<std::shared_ptr<siren::distributions::WeightableDistribution>>::reverse_iterator phys_it = unique_phys_distributions.rbegin();
                 phys_it != unique_phys_distributions.rend(); ++phys_it) {
             if((*gen_it) == (*phys_it)) {
+                cancelled_distribution_names.push_back((*gen_it)->Name());
                 unique_gen_distributions.erase(std::next(gen_it).base());
                 unique_phys_distributions.erase(std::next(phys_it).base());
                 break;

--- a/projects/injection/public/SIREN/injection/Weighter.tcc
+++ b/projects/injection/public/SIREN/injection/Weighter.tcc
@@ -84,11 +84,13 @@ void ProcessWeighter<ProcessType>::Initialize() {
     }
     unique_gen_distributions = GetInjectionDistributions();
     unique_phys_distributions = phys_process->GetPhysicalDistributions();
+    cancelled_distribution_names.clear();
     for(typename std::vector<std::shared_ptr<typename ProcessType::InjectionType>>::reverse_iterator gen_it = unique_gen_distributions.rbegin();
             gen_it != unique_gen_distributions.rend(); ++gen_it) {
         for(std::vector<std::shared_ptr<siren::distributions::WeightableDistribution>>::reverse_iterator phys_it = unique_phys_distributions.rbegin();
                 phys_it != unique_phys_distributions.rend(); ++phys_it) {
             if((*gen_it) == (*phys_it)) {
+                cancelled_distribution_names.push_back((*gen_it)->Name());
                 unique_gen_distributions.erase(std::next(gen_it).base());
                 unique_phys_distributions.erase(std::next(phys_it).base());
                 break;

--- a/python/Injector.py
+++ b/python/Injector.py
@@ -7,7 +7,8 @@ from . import interactions as _interactions
 from . import distributions as _distributions
 from . import injection as _injection
 
-import collections
+import json
+import warnings
 from functools import wraps
 
 from typing import Tuple, List, Dict, Optional, Union, Callable
@@ -28,7 +29,23 @@ SecondaryInjectionDistribution = _distributions.SecondaryInjectionDistribution
 SecondaryInjectionProcess = _injection.SecondaryInjectionProcess
 InteractionTreeDatum = _dataclasses.InteractionTreeDatum
 
+
 class Injector:
+    """Biased-sampling injector.
+
+    Two authoring surfaces compile to one engine configuration:
+
+    * the spec form ``Injector(detector=..., primary=Vertex(...),
+      secondaries=(...), events=N)`` builds each process from a Vertex; and
+    * the legacy keyword form (``number_of_events``, ``primary_type``,
+      ``primary_interactions``, the four ``secondary_*`` dicts,
+      ``stopping_condition``) is compiled through the same validation and
+      assembly path -- a translation shim, not a parallel code path.
+
+    ``generate(events)`` counts successful trees; ``report()`` renders the
+    engine failure ledger; ``engine`` exposes the raw C++ injector.
+    """
+
     def __init__(
         self,
         number_of_events: Optional[int] = None,
@@ -38,12 +55,18 @@ class Injector:
         primary_interactions: List[Union[_interactions.CrossSection, _interactions.Decay]] = None,
         primary_injection_distributions: List[_distributions.PrimaryInjectionDistribution] = None,
         primary_phase_spaces: Optional[Dict[_dataclasses.InteractionSignature, _injection.MultiChannelPhaseSpace]] = None,
-        primary_weighting_mode = None,
+        primary_weighting_mode=None,
         secondary_interactions: Optional[Dict[_dataclasses.ParticleType, List[Union[_interactions.CrossSection, _interactions.Decay]]]] = None,
         secondary_injection_distributions: Optional[Dict[_dataclasses.ParticleType, List[_distributions.SecondaryInjectionDistribution]]] = None,
         secondary_phase_spaces: Optional[Dict[_dataclasses.ParticleType, Dict[_dataclasses.InteractionSignature, _injection.MultiChannelPhaseSpace]]] = None,
         secondary_weighting_modes: Optional[Dict[_dataclasses.ParticleType, object]] = None,
         stopping_condition: Optional[Callable[[_dataclasses.InteractionTree, _dataclasses.InteractionTreeDatum, int], bool]] = None,
+        *,
+        detector: Optional[_detector.DetectorModel] = None,
+        primary=None,
+        secondaries=(),
+        events: Optional[int] = None,
+        max_attempts: Optional[int] = None,
     ):
         self.__seed = None
         self.__number_of_events = 0
@@ -62,6 +85,21 @@ class Injector:
         self.__stopping_condition = None
 
         self.__injector = None
+
+        # Spec-form fields (Vertex-based authoring).
+        self.__primary_vertex = None
+        self.__secondary_vertices = []
+        self.__primary_compiled_process = None
+        self.__secondary_compiled_processes = {}
+        self.__max_attempts = max_attempts
+
+        # Strong references to Python models/distributions/mixtures so their
+        # pybind trampolines survive gc while the compiled processes hold them.
+        self.__keepalive = []
+
+        detector_model = detector_model if detector_model is not None else detector
+        if events is not None:
+            number_of_events = events
 
         if seed is not None:
             self.__seed = seed
@@ -90,13 +128,36 @@ class Injector:
         if stopping_condition is not None:
             self.__stopping_condition = stopping_condition
 
+        if primary is not None:
+            self.__primary_vertex = primary
+            self.__secondary_vertices = list(secondaries)
 
-    def __initialize_injector(self):
+    # ------------------------------------------------------------------ #
+    #  Build (single validation choke point)                              #
+    # ------------------------------------------------------------------ #
+
+    def _build(self):
+        """Validate the configuration and construct the engine injector.
+
+        Every path -- spec Vertices or legacy kwargs -- lands here. It resolves
+        the RNG streams, compiles processes, checks the injection
+        distributions, expand wiring, per-signature name resolution and mixture
+        measures, runs the detector-dependent channel-density probe, and builds
+        the C++ injector.
+        """
+        from . import _validation
+        from . import errors as _errors
+        from . import expand as _expand
+
         if self.__seed is None:
             random = _utilities.SIREN_random()
             self.__seed = random.get_seed()
         else:
             random = _utilities.SIREN_random(self.__seed)
+        # An independent stream for config-time validation probes, so a probe
+        # draw never perturbs the generation stream. The seed is masked to the
+        # 32-bit range the RNG constructor accepts.
+        validation_random = _utilities.SIREN_random(int(self.__seed) & 0x7FFFFFFF)
 
         if self.__number_of_events is None:
             raise ValueError("number_of_events must be provided")
@@ -106,54 +167,60 @@ class Injector:
         if self.__detector_model is None:
             raise ValueError("detector_model must be provided")
 
+        if self.__primary_vertex is not None:
+            self._compile_from_vertices(_validation, _expand)
+
         if self.__primary_type is None:
             raise ValueError("primary_type must be provided")
-
         if len(self.__primary_interactions) == 0:
             raise ValueError("primary_interactions must be provided")
-
         if len(self.__primary_injection_distributions) == 0:
             raise ValueError("primary_injection_distributions must be provided")
 
-        if list(sorted(self.__secondary_interactions.keys())) != list(sorted(self.__secondary_injection_distributions.keys())):
-            raise ValueError("secondary_interactions and secondary_injection_distributions must have the same keys")
+        _validation.validate_injection_distributions(
+            self.__primary_injection_distributions)
 
-        primary_type = self.primary_type
-        primary_interaction_collection = _interactions.InteractionCollection(
-            primary_type, self.primary_interactions
+        # Cross-key validation of every secondary-keyed dict (a typo'd key in
+        # any of the four dicts raises here rather than silently vanishing).
+        _validation.validate_secondary_keys(
+            ("secondary_interactions", self.__secondary_interactions),
+            ("secondary_injection_distributions", self.__secondary_injection_distributions),
+            ("secondary_phase_spaces", self.__secondary_phase_spaces),
+            ("secondary_weighting_modes", self.__secondary_weighting_modes),
         )
-        primary_process = _injection.PrimaryInjectionProcess(
-            primary_type, primary_interaction_collection
-        )
-        primary_process.distributions = self.primary_injection_distributions
-        for sig, ps in self.__primary_phase_spaces.items():
-            primary_process.SetPhaseSpace(sig, ps)
-        if self.__primary_weighting_mode is not None:
-            primary_process.weighting_mode = self.__primary_weighting_mode
+        if sorted(self.__secondary_interactions.keys()) != sorted(
+                self.__secondary_injection_distributions.keys()):
+            raise ValueError(
+                "secondary_interactions and secondary_injection_distributions "
+                "must have the same keys")
 
-        secondary_interactions = self.secondary_interactions
-        secondary_injection_distributions = self.secondary_injection_distributions
+        # A chain with secondary processes but no expansion control -- neither
+        # a legacy stopping_condition nor Vertex expand/continue_if wiring (the
+        # latter is already checked above, in _compile_from_vertices, via
+        # validate_expansion_wiring) -- would silently prune every secondary:
+        # the engine's default stopping condition accepts primary-only trees
+        # unconditionally. This check runs regardless of how the secondaries
+        # were assembled, so it also covers the legacy secondary_interactions/
+        # secondary_injection_distributions dict form, which never reaches
+        # _compile_from_vertices.
+        if self.__secondary_interactions and self.__stopping_condition is None:
+            raise _errors.ConfigurationError(
+                "secondary processes are configured ({}) but no stopping "
+                "condition governs their expansion; the engine's default "
+                "stopping condition would silently prune every secondary. "
+                "Provide stopping_condition=..., or (spec form) wire "
+                "Vertex(expand=[...]).".format(
+                    sorted(str(k) for k in self.__secondary_interactions)))
 
-        secondary_interaction_collections = []
-        secondary_processes = []
-        for secondary_type, secondary_interactions in secondary_interactions.items():
-            secondary_interaction_collection = _interactions.InteractionCollection(
-                secondary_type, secondary_interactions
-            )
-            secondary_process = SecondaryInjectionProcess(
-                secondary_type, secondary_interaction_collection
-            )
-            secondary_process.distributions = secondary_injection_distributions[secondary_type]
-            if secondary_type in self.__secondary_phase_spaces:
-                for sig, ps in self.__secondary_phase_spaces[secondary_type].items():
-                    secondary_process.SetPhaseSpace(sig, ps)
-            if secondary_type in self.__secondary_weighting_modes:
-                secondary_process.weighting_mode = self.__secondary_weighting_modes[secondary_type]
-            secondary_processes.append(secondary_process)
+        primary_process = self._assemble_primary_process()
+        secondary_processes = self._assemble_secondary_processes()
+
+        self._probe_phase_spaces(
+            _validation, primary_process, secondary_processes, validation_random)
 
         self.__injector = _Injector(
-            self.number_of_events,
-            self.detector_model,
+            self.__number_of_events,
+            self.__detector_model,
             primary_process,
             secondary_processes,
             random,
@@ -162,19 +229,429 @@ class Injector:
         if self.__stopping_condition is not None:
             self.__injector.SetStoppingCondition(self.__stopping_condition)
 
-    # Custom method to retrieve the internal state for pickling
+    def _compile_from_vertices(self, _validation, _expand):
+        """Translate spec Vertices into the legacy field storage.
+
+        The compiled processes and their distributions/phase spaces are read
+        back into the same private fields the legacy path populates, so a
+        single assembly path serves both surfaces.
+        """
+        primary = self.__primary_vertex
+        all_vertices = [primary] + list(self.__secondary_vertices)
+        has_expand = any(v.expand or v.continue_if is not None
+                         for v in all_vertices)
+        _validation.check_expand_vs_legacy_stopping(
+            self.__stopping_condition is not None, has_expand)
+
+        self.__keepalive.append(primary)
+        self.__primary_type = primary._resolved_particle
+        self.__primary_interactions = list(primary.interactions)
+        self.__primary_injection_distributions = list(primary.distributions)
+
+        specs = [primary.as_vertex_spec()]
+        for sv in self.__secondary_vertices:
+            self.__keepalive.append(sv)
+            ptype = sv._resolved_particle
+            # Two secondary vertices resolving to the same particle type would
+            # each overwrite the other's interactions/distributions/process in
+            # the by-type maps below; require a single vertex per type.
+            if ptype in self.__secondary_interactions:
+                from . import errors as _errors
+                raise _errors.ConfigurationError(
+                    "two secondary vertices resolve to the same particle type "
+                    "{!r}; a chain admits one vertex per secondary type".format(
+                        str(ptype)))
+            self.__secondary_interactions[ptype] = list(sv.interactions)
+            self.__secondary_injection_distributions[ptype] = list(sv.distributions)
+            specs.append(sv.as_vertex_spec())
+
+        # Validate the expansion wiring whenever the chain carries secondaries
+        # and no legacy stopping_condition governs it. This is the only place
+        # the "secondaries declared but no expand rule anywhere" misconfiguration
+        # is caught: without it the engine's default stopping condition prunes
+        # every secondary, silently collapsing the chain to primary-only trees.
+        # A legacy stopping_condition takes control of expansion, so it passes
+        # through untouched. Compiling the expansion callable stays gated on
+        # has_expand; a legacy stopping_condition alone is left as supplied.
+        if self.__secondary_vertices and self.__stopping_condition is None:
+            _validation.validate_expansion_wiring(specs)
+        if self.__secondary_vertices and has_expand:
+            self.__stopping_condition = _expand.compile_expansion(specs)
+
+        # Compile per-signature phase spaces from each Vertex's kinematics.
+        primary_process = primary.compile(
+            is_primary=True, detector=self.__detector_model)
+        self.__primary_compiled_process = primary_process
+        self.__secondary_compiled_processes = {}
+        for sv in self.__secondary_vertices:
+            proc = sv.compile(is_primary=False, detector=self.__detector_model)
+            self.__secondary_compiled_processes[sv._resolved_particle] = proc
+
+    def _assemble_primary_process(self):
+        if self.__primary_compiled_process is not None:
+            return self.__primary_compiled_process
+        primary_interaction_collection = _interactions.InteractionCollection(
+            self.__primary_type, self.__primary_interactions)
+        primary_process = _injection.PrimaryInjectionProcess(
+            self.__primary_type, primary_interaction_collection)
+        primary_process.distributions = self.__primary_injection_distributions
+        for sig, ps in self.__primary_phase_spaces.items():
+            primary_process.SetPhaseSpace(sig, ps)
+        if self.__primary_weighting_mode is not None:
+            primary_process.weighting_mode = self.__primary_weighting_mode
+        return primary_process
+
+    def _assemble_secondary_processes(self):
+        if self.__secondary_compiled_processes:
+            return list(self.__secondary_compiled_processes.values())
+        secondary_processes = []
+        for secondary_type, sec_ints in self.__secondary_interactions.items():
+            secondary_interaction_collection = _interactions.InteractionCollection(
+                secondary_type, sec_ints)
+            secondary_process = SecondaryInjectionProcess(
+                secondary_type, secondary_interaction_collection)
+            secondary_process.distributions = (
+                self.__secondary_injection_distributions[secondary_type])
+            if secondary_type in self.__secondary_phase_spaces:
+                for sig, ps in self.__secondary_phase_spaces[secondary_type].items():
+                    secondary_process.SetPhaseSpace(sig, ps)
+            if secondary_type in self.__secondary_weighting_modes:
+                secondary_process.weighting_mode = (
+                    self.__secondary_weighting_modes[secondary_type])
+            secondary_processes.append(secondary_process)
+        return secondary_processes
+
+    def _probe_phase_spaces(self, _validation, primary_process,
+                            secondary_processes, validation_random):
+        """Run the detector-dependent ValidateChannelDensities probe.
+
+        Only mixtures actually registered on a process are probed. A typed
+        SIREN error (a measure incompatibility, a configuration error, a weight
+        calculation error, and every other error in ``errors.py``) is a real
+        fault and propagates; a probe that simply cannot run on the synthetic
+        template (unsolvable kinematics, missing target mass) surfaces as a bare
+        ValueError/TypeError/RuntimeError and is skipped -- the config-time
+        Mixture.validate() already screened measures without a detector.
+        """
+        typed_errors = _typed_siren_errors()
+        processes = [primary_process] + list(secondary_processes)
+        for process in processes:
+            ps_map = process.GetPhaseSpaceMap()
+            for sig, mcps in ps_map.items():
+                try:
+                    _validation.probe_channel_densities(
+                        mcps, sig, self.__detector_model, validation_random)
+                except typed_errors:
+                    raise
+                except (ValueError, TypeError, RuntimeError):
+                    continue
+
+    def __initialize_injector(self):
+        self._build()
+
+    # ------------------------------------------------------------------ #
+    #  Generation                                                          #
+    # ------------------------------------------------------------------ #
+
+    def generate(self, events=None, *, on_shortfall="warn", progress=None,
+                 min_efficiency=None):
+        """Generate `events` successful trees.
+
+        Retries failed ``GenerateEvent`` calls (never yields an empty tree) up
+        to ``max_attempts`` (default ``events * 1000``). Counts SUCCESSES, not
+        attempts. ``min_efficiency`` aborts early if the success rate falls
+        below it. On shortfall, ``on_shortfall`` chooses ``'warn'`` (default),
+        ``'raise'``, or ``'ignore'``, carrying an InjectionReport.
+        """
+        from . import errors as _errors
+
+        if self.__injector is None:
+            self._build()
+        if events is None:
+            events = self.__number_of_events
+        if events <= 0:
+            raise ValueError("events must be positive")
+
+        max_attempts = self.__max_attempts
+        if max_attempts is None:
+            max_attempts = events * 1000
+
+        # The engine throws once its own attempt quota (events_to_inject) is
+        # reached, so raise that quota to the retry budget; otherwise a
+        # sub-unity efficiency could never reach `events` successes.
+        self.__injector.ResetInjectedEvents(max_attempts)
+
+        # Give the efficiency estimate a minimum sample before it can abort, so
+        # an unlucky early run is not cut short.
+        min_efficiency_warmup = 50
+
+        trees = []
+        attempts = 0
+        while len(trees) < events and attempts < max_attempts:
+            attempts += 1
+            try:
+                tree = self.__injector.GenerateEvent()
+            except RuntimeError as err:
+                # The engine raises once its own attempt quota is exhausted;
+                # any other error is a real fault and must not be swallowed.
+                if "maximum number of injection attempts" in str(err):
+                    break
+                raise
+            if len(tree.tree) == 0:
+                continue
+            trees.append(tree)
+            if progress is not None:
+                progress(len(trees), events)
+            if (min_efficiency is not None and attempts >= min_efficiency_warmup
+                    and (len(trees) / attempts) < min_efficiency):
+                report = self.report()
+                message = (
+                    "injection efficiency {:.2%} fell below min_efficiency "
+                    "{:.2%} after {} attempts ({} succeeded)".format(
+                        len(trees) / attempts, min_efficiency, attempts,
+                        len(trees)))
+                self._handle_shortfall(on_shortfall, message, report, _errors)
+                return trees
+
+        if len(trees) < events:
+            report = self.report()
+            message = (
+                "requested {} events but only {} succeeded in {} attempts"
+                .format(events, len(trees), attempts))
+            self._handle_shortfall(on_shortfall, message, report, _errors)
+        return trees
+
+    def _handle_shortfall(self, on_shortfall, message, report, _errors):
+        if on_shortfall == "ignore":
+            return
+        if on_shortfall == "raise":
+            raise _errors.InjectionShortfall(message, report=report)
+        if on_shortfall == "warn":
+            warnings.warn(_errors.InjectionShortfall(message, report=report))
+            return
+        raise ValueError(
+            "on_shortfall must be 'warn', 'raise', or 'ignore', got {!r}"
+            .format(on_shortfall))
+
+    def reset(self, events=None):
+        """Reset the injected/attempt counters and failure ledger.
+
+        With ``events`` given, also change the target count.
+        """
+        if self.__injector is None:
+            if events is not None:
+                self.__number_of_events = events
+            return
+        if events is not None:
+            self.__injector.ResetInjectedEvents(events)
+            self.__number_of_events = events
+        else:
+            self.__injector.ResetInjectedEvents()
+
+    def report(self):
+        """Render the engine failure ledger as an InjectionReport."""
+        from .report import InjectionReport
+        if self.__injector is None:
+            return InjectionReport(0, 0, [], None)
+        ledger = self.__injector.GetFailureLedger()
+        attempts = self.__injector.InjectionAttempts()
+        successes = self.__injector.InjectedEvents()
+        last_tree = self.__injector.GetLastFailedTree()
+        return InjectionReport.from_ledger(
+            ledger, attempts=attempts, successes=successes,
+            last_failed_tree=last_tree)
+
+    # ------------------------------------------------------------------ #
+    #  Optimizer tuning I/O                                                #
+    # ------------------------------------------------------------------ #
+
+    def export_tuning(self, path=None):
+        """Return (and optionally write) each mixture's channel weights.
+
+        The result maps a stable mixture index to its weight list, so a tuned
+        run's channel weights can be reloaded via apply_tuning(). Reloading them
+        retunes the target run's generation density, so the same ordering rule
+        applies there as for apply_tuning(): weight only events generated after
+        the weights are applied.
+        """
+        if self.__injector is None:
+            self._build()
+        tuning = {}
+        for i, mcps in enumerate(self.__injector.GetPhaseSpaces()):
+            tuning[str(i)] = list(mcps.weights)
+        if path is not None:
+            with open(path, "w") as f:
+                json.dump(tuning, f)
+        return tuning
+
+    def apply_tuning(self, dict_or_path):
+        """Set each mixture's channel weights from a dict or a JSON path.
+
+        Retuning the channel weights changes the generation density g. Events
+        generated before this call carry no snapshot of the density that
+        produced them, so weighting them afterwards silently applies the new g
+        where the old one generated, biasing their weights. Always regenerate
+        after retuning and before weighting; the shipped drivers do (Simulation
+        .run tunes, resets, then generates before it weights).
+        """
+        if self.__injector is None:
+            self._build()
+        if isinstance(dict_or_path, str):
+            with open(dict_or_path) as f:
+                tuning = json.load(f)
+        else:
+            tuning = dict_or_path
+        mixtures = self.__injector.GetPhaseSpaces()
+        for key, weights in tuning.items():
+            idx = int(key)
+            if idx < len(mixtures):
+                mixtures[idx].weights = list(weights)
+                mixtures[idx].Normalize()
+
+    # ------------------------------------------------------------------ #
+    #  Introspection                                                       #
+    # ------------------------------------------------------------------ #
+
+    @property
+    def engine(self):
+        """The raw C++ injector, building it on first access."""
+        if self.__injector is None:
+            self._build()
+        return self.__injector
+
+    def describe(self):
+        """A short human-readable description of the configuration."""
+        lines = ["Injector(events={}, primary={})".format(
+            self.__number_of_events, self.__primary_type)]
+        if self.__secondary_interactions:
+            lines.append("  secondaries: {}".format(
+                sorted(str(k) for k in self.__secondary_interactions)))
+        return "\n".join(lines)
+
+    def to_dict(self):
+        """A plain-dict snapshot of the configuration counts."""
+        return {
+            "events": self.__number_of_events,
+            "seed": self.__seed,
+            "primary_type": str(self.__primary_type),
+            "secondary_types": [str(k) for k in self.__secondary_interactions],
+        }
+
+    def save(self, filename):
+        """Serialize the injector, refusing configurations that cannot survive.
+
+        The engine archives processes, including weighting modes and phase-space
+        maps, but not a stopping condition, and it cannot serialize Python
+        trampoline-derived interactions/distributions. Unsupported Python state
+        raises NotSerializableError instead. Pickle preserves the stopping
+        condition, so pickle a chain that needs one.
+        """
+        from . import errors as _errors
+        if self.__injector is None:
+            self._build()
+        self._guard_serializable(_errors)
+        self.__injector.SaveInjector(filename)
+
+    def _guard_serializable(self, _errors, for_pickle=False):
+        offenders = []
+        # The stopping condition rides along in the pickle state tuple, so
+        # pickle preserves it; the standalone C++ archive cannot.
+        if self.__stopping_condition is not None and not for_pickle:
+            offenders.append(
+                "a stopping condition is set (not archived; use pickle, which "
+                "preserves it)")
+        for interaction in self.__primary_interactions:
+            if _is_trampoline(interaction):
+                offenders.append(
+                    "primary interaction {!r} is a Python subclass (not "
+                    "serializable)".format(type(interaction).__name__))
+        for dist in self.__primary_injection_distributions:
+            if _is_trampoline(dist):
+                offenders.append(
+                    "primary distribution {!r} is a Python subclass (not "
+                    "serializable)".format(type(dist).__name__))
+        for stype, interactions in self.__secondary_interactions.items():
+            for interaction in interactions:
+                if _is_trampoline(interaction):
+                    offenders.append(
+                        "secondary interaction {!r} for type {} is a Python "
+                        "subclass (not serializable)".format(
+                            type(interaction).__name__, str(stype)))
+        for stype, dists in self.__secondary_injection_distributions.items():
+            for dist in dists:
+                if _is_trampoline(dist):
+                    offenders.append(
+                        "secondary distribution {!r} for type {} is a Python "
+                        "subclass (not serializable)".format(
+                            type(dist).__name__, str(stype)))
+        if offenders:
+            raise _errors.NotSerializableError(
+                "this injector cannot be saved without silently changing "
+                "physics on reload:\n  - " + "\n  - ".join(offenders),
+                offenders=offenders)
+
+    @classmethod
+    def load(cls, filename):
+        """Construct an Injector from a saved archive.
+
+        The archive omits the random engine, so the reloaded injector is given
+        a FRESH, unseeded generation stream. RNG streams do not resume across
+        save/load: a saved seed is not restored, and generation begins anew.
+        (save() drops any stopping condition; pickle a chain that needs one.)
+        """
+        obj = cls()
+        # Construct the engine through the archive-loading constructor rather
+        # than loading into a __new__-allocated shell: __new__ allocates the
+        # C++ storage without running any constructor, so the shell has no
+        # vtable and the first virtual call (GetDetectorModel below) crashes.
+        # The constructor also takes the random engine the archive omits, so
+        # generate() does not dereference a null RNG; the event count is a
+        # placeholder LoadInjector immediately overwrites from the archive.
+        # load() starts a fresh unseeded stream and records the drawn seed so
+        # obj.seed reflects the live stream.
+        _random = _utilities.SIREN_random()
+        obj.__injector = _Injector(1, filename, _random)
+        obj.__seed = _random.get_seed()
+        obj.__number_of_events = obj.__injector.EventsToInject()
+        obj.__detector_model = obj.__injector.GetDetectorModel()
+        primary_process = obj.__injector.GetPrimaryProcess()
+        obj.__primary_type = primary_process.primary_type
+        obj.__primary_interactions = list(
+            primary_process.interactions.GetCrossSections()) + list(
+            primary_process.interactions.GetDecays())
+        obj.__primary_injection_distributions = list(primary_process.distributions)
+        obj.__primary_phase_spaces = primary_process.GetPhaseSpaceMap()
+        obj.__secondary_interactions = {}
+        obj.__secondary_injection_distributions = {}
+        obj.__secondary_phase_spaces = {}
+        for stype, sproc in obj.__injector.GetSecondaryProcessMap().items():
+            obj.__secondary_interactions[stype] = list(
+                sproc.interactions.GetCrossSections()) + list(
+                sproc.interactions.GetDecays())
+            obj.__secondary_injection_distributions[stype] = list(sproc.distributions)
+            obj.__secondary_phase_spaces[stype] = sproc.GetPhaseSpaceMap()
+        return obj
+
+    # ------------------------------------------------------------------ #
+    #  Pickling                                                            #
+    # ------------------------------------------------------------------ #
+
     def __getstate__(self):
-        # The seed and stopping condition are the only things we cannot serialize
-        state = (self.__seed, self.__stopping_condition, self.__injector.__getstate__())
-        return state
+        from . import errors as _errors
+        # Build first: an unbuilt injector has no engine to pickle, and building
+        # resolves the generation seed so the state tuple carries a concrete
+        # seed (a fresh injector re-seeded from it reproduces this stream from
+        # the start). The guard then refuses exactly what save() refuses, minus
+        # the stopping condition -- the state tuple preserves that.
+        if self.__injector is None:
+            self._build()
+        self._guard_serializable(_errors, for_pickle=True)
+        return (self.__seed, self.__stopping_condition,
+                self.__injector.__getstate__())
 
-    # Custom method to restore the state from a pickle
     def __setstate__(self, state):
-
         self.__seed, self.__stopping_condition, injector_state = state
-
-        # Create a new instance of the C++ class and restore its state
-        self.__injector = _Injector.__new__(_Injector)  # Create an empty instance
+        self.__injector = _Injector.__new__(_Injector)
         if self.__injector is None:
             raise TypeError("Failed to create C++ Injector object")
         self.__injector.__setstate__(injector_state)
@@ -184,15 +661,39 @@ class Injector:
         self.__primary_type = primary_process.primary_type
         self.__primary_interactions = list(primary_process.interactions.GetCrossSections()) + list(primary_process.interactions.GetDecays())
         self.__primary_injection_distributions = list(primary_process.distributions)
-        self.__primary_phase_spaces = {}
-
+        self.__primary_phase_spaces = primary_process.GetPhaseSpaceMap()
         self.__secondary_interactions = {}
         self.__secondary_injection_distributions = {}
         self.__secondary_phase_spaces = {}
+        self.__primary_vertex = None
+        self.__secondary_vertices = []
+        self.__primary_compiled_process = None
+        self.__secondary_compiled_processes = {}
+        self.__keepalive = []
+        self.__max_attempts = None
         for secondary_type, secondary_process in self.__injector.GetSecondaryProcessMap().items():
             self.__secondary_interactions[secondary_type] = list(secondary_process.interactions.GetCrossSections()) + list(secondary_process.interactions.GetDecays())
             self.__secondary_injection_distributions[secondary_type] = list(secondary_process.distributions)
-            # Phase spaces are per-signature and are not serialized through cereal, so this does not recover them.
+            self.__secondary_phase_spaces[secondary_type] = secondary_process.GetPhaseSpaceMap()
+        # The C++ archive omits the random engine, so install a fresh one:
+        # generate() skips _build once the engine exists and would otherwise
+        # dereference a null RNG. RNG streams do NOT resume across a pickle
+        # round-trip -- the stored seed re-seeds a fresh stream, so a fresh
+        # injector and this unpickled one produce the same stream from the
+        # start (the seed was resolved during __getstate__'s build).
+        if self.__seed is not None:
+            self.__injector.SetRandom(_utilities.SIREN_random(self.__seed))
+        else:
+            self.__injector.SetRandom(_utilities.SIREN_random())
+        # The stopping condition rode along in the state tuple but must be
+        # re-attached to the engine; otherwise the engine default prunes every
+        # secondary and silently truncates chains.
+        if self.__stopping_condition is not None:
+            self.__injector.SetStoppingCondition(self.__stopping_condition)
+
+    # ------------------------------------------------------------------ #
+    #  Properties (legacy surface, retained)                              #
+    # ------------------------------------------------------------------ #
 
     @property
     def seed(self):
@@ -202,7 +703,9 @@ class Injector:
     def seed(self, seed):
         self.__seed = seed
         if self.__injector is not None:
-            self.__injector.GetRandom().set_seed(seed)
+            # The engine exposes only SetRandom; install a fresh engine
+            # seeded from the new value (streams restart, not resume).
+            self.__injector.SetRandom(_utilities.SIREN_random(seed))
 
     @property
     def number_of_events(self):
@@ -342,7 +845,7 @@ class Injector:
     @wraps(_Injector.GenerateEvent)
     def generate_event(self):
         if self.__injector is None:
-            self.__initialize_injector()
+            self._build()
         return self.__injector.GenerateEvent()
     generate_event.__name__ = "generate_event"
     generate_event.__doc__ = _Injector.GenerateEvent.__doc__.replace("GenerateEvent", "generate_event")
@@ -359,48 +862,60 @@ class Injector:
             return self.__injector.InjectedEvents()
         return 0
 
+    @property
+    def injection_attempts(self):
+        if self.__injector is not None:
+            return self.__injector.InjectionAttempts()
+        return 0
+
     @wraps(_Injector.ResetInjectedEvents)
     def reset_injected_events(self):
         if self.__injector is not None:
             self.__injector.ResetInjectedEvents()
     reset_injected_events.__name__ = "reset_injected_events"
-    reset_injected_events.__doc__ = _Injector.ResetInjectedEvents.__doc__.replace("ResetInjectedEvents", "reset_injected_events")
-
-    @wraps(_Injector.SaveInjector)
-    def save(self, filename):
-        self.__injector.SaveInjector(filename)
-    save.__name__ = "save"
-    save.__doc__ = _Injector.SaveInjector.__doc__.replace("SaveInjector", "save")
 
     def __iter__(self):
-        """Iterate over generated events.
+        """Iterate raw generation attempts (yields empty trees on failure).
 
-        Yields one ``InteractionTree`` per event, up to
-        ``number_of_events``.
+        Deprecated: kept for backward compatibility. Prefer generate(), which
+        counts successes and never yields an empty tree.
         """
+        warnings.warn(
+            "iterating an Injector yields raw attempts including empty trees; "
+            "use generate(events) which counts successes",
+            DeprecationWarning, stacklevel=2)
         if self.__injector is None:
-            self.__initialize_injector()
+            self._build()
         for _ in range(self.number_of_events):
             yield self.__injector.GenerateEvent()
 
     def __len__(self):
         return self.number_of_events
 
-    @wraps(_Injector.LoadInjector)
-    def load(self, filename):
-        self.__injector.LoadInjector(filename)
-        # Update Python object state after loading
-        self.__number_of_events = self.__injector.EventsToInject()
-        self.__detector_model = self.__injector.GetDetectorModel()
-        primary_process = self.__injector.GetPrimaryProcess()
-        self.__primary_type = primary_process.primary_type
-        self.__primary_interactions = list(primary_process.interactions.GetCrossSections()) + list(primary_process.interactions.GetDecays())
-        self.__primary_injection_distributions = list(primary_process.distributions)
 
-        self.__secondary_interactions = {}
-        self.__secondary_injection_distributions = {}
-        for secondary_type, secondary_process in self.__injector.GetSecondaryProcessMap().items():
-            self.__secondary_interactions[secondary_type] = list(secondary_process.interactions.GetCrossSections()) + list(secondary_process.interactions.GetDecays())
-            self.__secondary_injection_distributions[secondary_type] = list(secondary_process.distributions)
+def _typed_siren_errors():
+    """The tuple of typed SIREN exception classes exported by ``errors.py``.
 
-        self.__stopping_condition = self.__injector.GetStoppingCondition()
+    Every name in ``errors.py`` derives from ``RuntimeError``; a probe raising
+    any of them signals a real fault that must propagate rather than be treated
+    as probe-inapplicability.
+    """
+    from . import errors as _errors
+    classes = []
+    for name in dir(_errors):
+        obj = getattr(_errors, name)
+        if isinstance(obj, type) and issubclass(obj, BaseException) \
+                and issubclass(obj, RuntimeError):
+            classes.append(obj)
+    return tuple(classes)
+
+
+def _is_trampoline(obj):
+    """Whether `obj` is a Python subclass of a pybind base (a trampoline).
+
+    A C++-native pybind object's type is defined in an extension module; a
+    Python subclass is defined in a .py module, so its class __module__ does
+    not start with 'siren.'.
+    """
+    module = type(obj).__module__ or ""
+    return not module.startswith("siren.") and module not in ("builtins",)

--- a/python/Injector.py
+++ b/python/Injector.py
@@ -354,7 +354,7 @@ class Injector:
     # ------------------------------------------------------------------ #
 
     def generate(self, events=None, *, on_shortfall="warn", progress=None,
-                 min_efficiency=None):
+                 min_efficiency=None, on_failure="retry"):
         """Generate `events` successful trees.
 
         Retries failed ``GenerateEvent`` calls (never yields an empty tree) up
@@ -362,9 +362,15 @@ class Injector:
         attempts. ``min_efficiency`` aborts early if the success rate falls
         below it. On shortfall, ``on_shortfall`` chooses ``'warn'`` (default),
         ``'raise'``, or ``'ignore'``, carrying an InjectionReport.
+
+        ``on_failure``: ``'retry'`` (default) retries failed attempts; ``'raise'``
+        raises GenerationFailure except for NoPathThroughVolume and
+        NoTargetsOnPath, which are retried.
         """
         from . import errors as _errors
 
+        if on_failure not in ("retry", "raise"):
+            raise ValueError("on_failure must be 'retry' or 'raise'")
         if self.__injector is None:
             self._build()
         if events is None:
@@ -398,6 +404,21 @@ class Injector:
                     break
                 raise
             if len(tree.tree) == 0:
+                if on_failure == "raise":
+                    allowed = (_injection.FailureReason.NoPathThroughVolume,
+                               _injection.FailureReason.NoTargetsOnPath)
+                    report = self.report()
+                    failures = [bucket for bucket in report.by_vertex
+                                if bucket.reason not in allowed]
+                    if failures or not report.by_vertex:
+                        details = "\n".join(
+                            "{} at depth {}, parent {}: {}".format(
+                                bucket.reason_name, bucket.depth,
+                                bucket.pdg, bucket.exemplar)
+                            for bucket in failures)
+                        raise _errors.GenerationFailure(
+                            "injection failed: " + (details or "no failure diagnosis"),
+                            report=report)
                 continue
             trees.append(tree)
             if progress is not None:
@@ -542,8 +563,9 @@ class Injector:
 
         The engine archives processes, including weighting modes and phase-space
         maps, but not a stopping condition, and it cannot serialize Python
-        trampoline-derived interactions/distributions. Unsupported Python state
-        raises NotSerializableError instead. Pickle preserves the stopping
+        trampoline-derived interactions/distributions or vertex physical
+        declarations. Save the Weighter to archive its physical processes.
+        Unsupported state raises NotSerializableError. Pickle preserves the stopping
         condition, so pickle a chain that needs one.
         """
         from . import errors as _errors
@@ -552,8 +574,19 @@ class Injector:
         self._guard_serializable(_errors)
         self.__injector.SaveInjector(filename)
 
-    def _guard_serializable(self, _errors, for_pickle=False):
+    def _guard_serializable(self, _errors, for_pickle=False, for_weighter=False):
         offenders = []
+        # Injector archives contain sampling processes only. A Weighter archive
+        # also stores the resolved physical processes, so it preserves these.
+        if not for_weighter:
+            vertices = ([self.__primary_vertex] if self.__primary_vertex is not None else [])
+            vertices += self.__secondary_vertices
+            for vertex in vertices:
+                if vertex.physical or vertex.physical_interactions is not None:
+                    offenders.append(
+                        "vertex {!r} declares physical models/distributions "
+                        "(not archived by Injector; save the Weighter instead)"
+                        .format(vertex.particle))
         # The stopping condition rides along in the pickle state tuple, so
         # pickle preserves it; the standalone C++ archive cannot.
         if self.__stopping_condition is not None and not for_pickle:
@@ -694,6 +727,16 @@ class Injector:
     # ------------------------------------------------------------------ #
     #  Properties (legacy surface, retained)                              #
     # ------------------------------------------------------------------ #
+
+    @property
+    def primary(self):
+        """The primary Vertex, or None for a legacy/loaded injector."""
+        return self.__primary_vertex
+
+    @property
+    def secondaries(self):
+        """The secondary Vertices, in declaration order."""
+        return tuple(self.__secondary_vertices)
 
     @property
     def seed(self):

--- a/python/Weighter.py
+++ b/python/Weighter.py
@@ -7,12 +7,14 @@ from . import interactions as _interactions
 from . import distributions as _distributions
 from . import injection as _injection
 from . import Injector as _Injector_module
+from .Injector import _is_trampoline
 from ._validation import validate_reweighting_compatibility
 
-from dataclasses import dataclass, field
 from typing import Tuple, List, Dict, Optional, Union, Callable
 from typing import TYPE_CHECKING
-import math
+import warnings
+
+import numpy as np
 
 if TYPE_CHECKING:
     import siren
@@ -27,57 +29,6 @@ CrossSection = _interactions.CrossSection
 Decay = _interactions.Decay
 DetectorModel = _detector.DetectorModel
 InteractionTree = _dataclasses.InteractionTree
-
-@dataclass
-class VertexWeight:
-    """Per-vertex weight components."""
-    depth: int = 0
-    primary_type: int = 0
-    secondary_types: List[int] = field(default_factory=list)
-    interaction_probability: float = float('nan')
-    position_probability: float = float('nan')
-    physical_probability: float = float('nan')
-    generation_probability: float = float('nan')
-
-    @property
-    def vertex_weight(self) -> float:
-        if self.generation_probability == 0:
-            return float('inf')
-        return self.physical_probability / self.generation_probability
-
-    @property
-    def is_ok(self) -> bool:
-        return (math.isfinite(self.physical_probability)
-                and self.physical_probability > 0
-                and math.isfinite(self.generation_probability)
-                and self.generation_probability > 0)
-
-    def __repr__(self):
-        flag = "" if self.is_ok else " !!!"
-        return (
-            f"VertexWeight(d={self.depth} {self.primary_type}"
-            f"->{self.secondary_types} "
-            f"phys={self.physical_probability:.3e} "
-            f"gen={self.generation_probability:.3e} "
-            f"w={self.vertex_weight:.3e}{flag})"
-        )
-
-
-@dataclass
-class EventWeightBreakdown:
-    """Decomposition of an event weight into per-vertex factors."""
-    vertices: List[VertexWeight] = field(default_factory=list)
-    weight: float = float('nan')
-
-    @property
-    def is_ok(self) -> bool:
-        return math.isfinite(self.weight) and self.weight > 0
-
-    def __repr__(self):
-        lines = [f"EventWeightBreakdown(weight={self.weight:.6e})"]
-        for v in self.vertices:
-            lines.append(f"  {v!r}")
-        return "\n".join(lines)
 
 
 class Weighter:
@@ -96,7 +47,8 @@ class Weighter:
     interaction datum.
     """
 
-    def __init__(self, 
+    def __init__(self,
+        *args,
         injectors: Optional[List[_Injector]] = None,
         detector_model: Optional[DetectorModel] = None,
         primary_type: Optional[_dataclasses.ParticleType] = None,
@@ -104,18 +56,42 @@ class Weighter:
         primary_physical_distributions: Optional[List[_distributions.WeightableDistribution]] = None,
         secondary_interactions: Optional[Dict[_dataclasses.ParticleType, List[Union[_interactions.CrossSection, _interactions.Decay]]]] = None,
         secondary_physical_distributions: Optional[Dict[_dataclasses.ParticleType, List[_distributions.WeightableDistribution]]] = None,
+        primary_physical: Optional[List[_distributions.WeightableDistribution]] = None,
+        secondary_physical: Optional[Dict[_dataclasses.ParticleType, List[_distributions.WeightableDistribution]]] = None,
+        overrides: Optional[Dict[str, object]] = None,
     ):
         """
         Initialize the Weighter with interactions and physical processes.
 
+        Two calling conventions are supported.
+
+        Legacy keyword form::
+
+            Weighter(injectors=[...], detector_model=..., primary_type=...,
+                     primary_interactions=..., primary_physical_distributions=...,
+                     secondary_interactions=..., secondary_physical_distributions=...)
+
+        Spec form, positional injectors plus physical-side keywords, inheriting
+        detector/types/interactions from the injectors themselves::
+
+            Weighter(injector, primary_physical=[...], secondary_physical={...})
+
+        ``overrides`` (spec form only) is a dict of legacy field names
+        (``detector_model``, ``primary_type``, ``primary_interactions``,
+        ``secondary_interactions``) to override what would otherwise be
+        inherited from the injectors.
+
         Args:
-            injectors: List of injector objects.
+            injectors: List of injector objects (legacy keyword form).
             detector_model: The detector model.
             primary_type: The primary particle type.
             primary_interactions: Dictionary of primary particle interactions.
             primary_physical_distributions: List of primary physical distributions.
             secondary_interactions: Dictionary of secondary particle interactions.
             secondary_physical_distributions: Dictionary of secondary physical distributions.
+            primary_physical: Primary physical distributions (spec form).
+            secondary_physical: Secondary physical distributions (spec form).
+            overrides: Legacy-field overrides for the spec form.
 
         Note:
             All parameters are optional and can be set later using property setters.
@@ -133,6 +109,22 @@ class Weighter:
 
         self.__weighter = None
 
+        spec_injectors = self.__detect_spec_injectors(args, injectors)
+
+        if spec_injectors is not None:
+            self.__init_from_injectors(
+                spec_injectors, primary_physical, secondary_physical, overrides)
+            return
+
+        if len(args) == 1 and injectors is None:
+            # Legacy form with injectors passed positionally as a list.
+            injectors = args[0]
+        elif len(args) > 1:
+            raise TypeError(
+                "Weighter() accepts either legacy keyword arguments or "
+                "one-or-more positional Injector arguments, not {} "
+                "positional arguments".format(len(args)))
+
         if injectors is not None:
             self.injectors = injectors
         if detector_model is not None:
@@ -147,6 +139,60 @@ class Weighter:
             self.__secondary_interactions = secondary_interactions
         if secondary_physical_distributions is not None:
             self.__secondary_physical_distributions = secondary_physical_distributions
+
+    @staticmethod
+    def __detect_spec_injectors(args, injectors_kwarg):
+        """Return the positional injectors list if this is the spec-form call.
+
+        Spec form is detected by one-or-more positional args that are each an
+        Injector (python wrapper or raw C++ engine), with no ``injectors=``
+        keyword given. A single positional list (the legacy form) is left for
+        the caller to handle.
+        """
+        if injectors_kwarg is not None:
+            return None
+        if len(args) == 0:
+            return None
+        if len(args) == 1 and isinstance(args[0], list):
+            return None
+        if all(isinstance(a, (_Injector, _PyInjector)) for a in args):
+            return list(args)
+        return None
+
+    def __init_from_injectors(self, injectors, primary_physical,
+                               secondary_physical, overrides):
+        """Populate fields by inheriting from the given injectors' processes."""
+        overrides = overrides or {}
+
+        self.injectors = injectors
+
+        engine0 = injectors[0].engine if isinstance(injectors[0], _PyInjector) else injectors[0]
+        primary_proc = engine0.GetPrimaryProcess()
+
+        self.__detector_model = overrides.get(
+            "detector_model",
+            injectors[0].detector_model if isinstance(injectors[0], _PyInjector)
+            else engine0.GetDetectorModel())
+        self.__primary_type = overrides.get(
+            "primary_type", primary_proc.primary_type)
+        self.__primary_interactions = overrides.get(
+            "primary_interactions",
+            list(primary_proc.interactions.GetCrossSections())
+            + list(primary_proc.interactions.GetDecays()))
+
+        secondary_interactions = overrides.get("secondary_interactions", None)
+        if secondary_interactions is None:
+            secondary_interactions = {}
+            for ptype, sproc in engine0.GetSecondaryProcessMap().items():
+                secondary_interactions[ptype] = (
+                    list(sproc.interactions.GetCrossSections())
+                    + list(sproc.interactions.GetDecays()))
+        self.__secondary_interactions = secondary_interactions
+
+        self.__primary_physical_distributions = (
+            list(primary_physical) if primary_physical is not None else [])
+        self.__secondary_physical_distributions = (
+            dict(secondary_physical) if secondary_physical is not None else {})
 
     @property
     def injectors(self) -> List[_Injector]:
@@ -169,7 +215,11 @@ class Weighter:
         Raises:
             ValueError: If the weighter has already been initialized.
             TypeError: If the input is not a list of Injector objects.
-            ValueError: If any of the injectors are not initialized.
+
+        Note:
+            A python Injector wrapper need not already have built its
+            underlying engine -- it is unwrapped via its ``engine`` property
+            (which builds it lazily) at weighter-initialize time.
         """
 
         if self.__weighter is not None:
@@ -178,8 +228,6 @@ class Weighter:
             raise TypeError("Injectors must be a list.")
         if not all(isinstance(injector, (_Injector, _PyInjector)) for injector in injectors):
             raise TypeError("All injectors must be of type Injector.")
-        if not all(injector._Injector__injector is not None for injector in injectors if isinstance(injector, _PyInjector)):
-            raise ValueError("All injectors must be initialized.")
         self.__injectors = injectors
 
     @property
@@ -376,12 +424,63 @@ class Weighter:
         """
         Serialize the weighter to ``<filename>.siren_weighter``.
 
+        Phase space maps are archived with their processes. Configurations that
+        still cannot survive the round-trip -- Python trampoline-derived
+        interactions or distributions, and a Python injector's stopping
+        condition -- raise NotSerializableError instead.
+
         Args:
             filename: Base path; the ".siren_weighter" suffix is added.
         """
+        from . import errors as _errors
         if self.__weighter is None:
             self.__initialize_weighter()
+        self._guard_serializable(_errors)
         self.__weighter.SaveWeighter(filename)
+
+    def _guard_serializable(self, _errors):
+        """Collect configurations that cannot survive a save/load round-trip.
+
+        Phase space maps are archived. The weighter checks its own Python
+        trampoline models and defers to each Python injector's guard for its
+        remaining unsupported trampoline and stopping-condition state.
+        """
+        offenders = []
+        for injector in (self.__injectors or []):
+            if isinstance(injector, _PyInjector):
+                try:
+                    injector._guard_serializable(_errors)
+                except _errors.NotSerializableError as exc:
+                    offenders.extend("injector: " + o for o in exc.offenders)
+        for interaction in self.__primary_interactions:
+            if _is_trampoline(interaction):
+                offenders.append(
+                    "primary interaction {!r} is a Python subclass (not "
+                    "serializable)".format(type(interaction).__name__))
+        for dist in self.__primary_physical_distributions:
+            if _is_trampoline(dist):
+                offenders.append(
+                    "primary distribution {!r} is a Python subclass (not "
+                    "serializable)".format(type(dist).__name__))
+        for stype, interactions in self.__secondary_interactions.items():
+            for interaction in interactions:
+                if _is_trampoline(interaction):
+                    offenders.append(
+                        "secondary interaction {!r} for type {} is a Python "
+                        "subclass (not serializable)".format(
+                            type(interaction).__name__, str(stype)))
+        for stype, dists in self.__secondary_physical_distributions.items():
+            for dist in dists:
+                if _is_trampoline(dist):
+                    offenders.append(
+                        "secondary distribution {!r} for type {} is a Python "
+                        "subclass (not serializable)".format(
+                            type(dist).__name__, str(stype)))
+        if offenders:
+            raise _errors.NotSerializableError(
+                "this weighter cannot be saved without silently changing "
+                "physics on reload:\n  - " + "\n  - ".join(offenders),
+                offenders=offenders)
 
     def load(self, filename: str):
         """
@@ -399,13 +498,29 @@ class Weighter:
             filename: Base path; the ".siren_weighter" suffix is added.
         """
         if self.__injectors is not None:
-            injectors = [injector._Injector__injector if isinstance(injector, _PyInjector) else injector
+            injectors = [injector.engine if isinstance(injector, _PyInjector) else injector
                          for injector in self.__injectors]
         else:
             injectors = []
         self.__weighter = _Weighter(injectors, filename)
+        self.__detector_model = self.__weighter.GetDetectorModel()
+        primary_process = self.__weighter.GetPrimaryPhysicalProcess()
+        self.__primary_type = primary_process.primary_type
+        self.__primary_interactions = list(
+            primary_process.interactions.GetCrossSections()) + list(
+            primary_process.interactions.GetDecays())
+        self.__primary_physical_distributions = list(primary_process.distributions)
+        self.__secondary_interactions = {}
+        self.__secondary_physical_distributions = {}
+        for secondary_process in self.__weighter.GetSecondaryPhysicalProcesses():
+            stype = secondary_process.primary_type
+            self.__secondary_interactions[stype] = list(
+                secondary_process.interactions.GetCrossSections()) + list(
+                secondary_process.interactions.GetDecays())
+            self.__secondary_physical_distributions[stype] = list(
+                secondary_process.distributions)
 
-    def weight_all(self, events) -> list:
+    def weight_all(self, events) -> "np.ndarray":
         """
         Calculate weights for a list of events.
 
@@ -413,77 +528,43 @@ class Weighter:
             events: A list of InteractionTree objects.
 
         Returns:
-            list[float]: The calculated event weights.
+            numpy.ndarray: The calculated event weights.
         """
-        return [self(event) for event in events]
+        return np.array([self(event) for event in events])
 
-    def breakdown(self, interaction_tree: InteractionTree) -> "EventWeightBreakdown":
-        """Per-vertex decomposition of the event weight.
-
-        Returns an ``EventWeightBreakdown`` that stores each vertex's
-        interaction probability, position density, physical probability,
-        and generation probability.  Useful for diagnosing inf/0/NaN
-        weights.
-        """
+    @property
+    def engine(self) -> _Weighter:
+        """The raw C++ _Weighter, building it via __initialize_weighter if needed."""
         if self.__weighter is None:
             self.__initialize_weighter()
+        return self.__weighter
 
-        injector_idx = 0
-        cpp_inj = self.__injectors[injector_idx]
-        if isinstance(cpp_inj, _PyInjector):
-            cpp_inj = cpp_inj._Injector__injector
+    def explain(self, interaction_tree: InteractionTree) -> "report.WeightBreakdown":
+        """Per-vertex decomposition of the event weight.
 
-        sec_map = cpp_inj.GetSecondaryProcessMap()
+        Returns a ``report.WeightBreakdown`` built from the engine's
+        ``EventWeightWithBreakdown``, giving each vertex's generation and
+        physical probability, channel densities, cancelled distributions, and
+        diagnostic flags. Useful for diagnosing inf/0/NaN weights.
+        """
+        from .report import WeightBreakdown
+        if self.__weighter is None:
+            self.__initialize_weighter()
+        return WeightBreakdown.from_engine(
+            self.engine.EventWeightWithBreakdown(interaction_tree))
 
-        primary_phys = self.__weighter_primary_phys
-        secondary_phys = self.__weighter_secondary_phys
-        ppw = _injection.PrimaryProcessWeighter(
-            primary_phys, cpp_inj.GetPrimaryProcess(),
-            self.__detector_model)
+    def breakdown(self, interaction_tree: InteractionTree) -> "report.WeightBreakdown":
+        """Deprecated alias of explain().
 
-        vertices = []
-        for datum in interaction_tree.tree:
-            rec = datum.record
-            pid = rec.signature.primary_type
-            depth = datum.depth(interaction_tree)
-            secs = list(rec.signature.secondary_types)
-
-            if depth == 0:
-                bounds = cpp_inj.PrimaryInjectionBounds(rec)
-                pw = ppw
-            else:
-                bounds = cpp_inj.SecondaryInjectionBounds(rec)
-                if pid not in secondary_phys:
-                    vertices.append(VertexWeight(
-                        depth=depth, primary_type=int(pid),
-                        secondary_types=[int(s) for s in secs]))
-                    continue
-                pw = _injection.SecondaryProcessWeighter(
-                    secondary_phys[pid], sec_map[pid],
-                    self.__detector_model)
-
-            int_prob = pw.InteractionProbability(bounds, rec)
-            pos_prob = pw.NormalizedPositionProbability(bounds, rec)
-            phys_prob = pw.PhysicalProbability(bounds, rec)
-            gen_prob = pw.GenerationProbability(datum)
-
-            vertices.append(VertexWeight(
-                depth=depth,
-                primary_type=int(pid),
-                secondary_types=[int(s) for s in secs],
-                interaction_probability=int_prob,
-                position_probability=pos_prob,
-                physical_probability=phys_prob,
-                generation_probability=gen_prob,
-            ))
-
-        return EventWeightBreakdown(
-            vertices=vertices,
-            weight=self(interaction_tree),
-        )
+        Retained for backward compatibility; emits a DeprecationWarning and
+        returns the same ``report.WeightBreakdown`` as explain().
+        """
+        warnings.warn(
+            "Weighter.breakdown() is deprecated, use Weighter.explain() instead",
+            DeprecationWarning, stacklevel=2)
+        return self.explain(interaction_tree)
 
     def __initialize_weighter(self):
-        # Thin wrapper kept separate so breakdown() can call the initialization directly.
         return self.__do_initialize_weighter()
 
     def __do_initialize_weighter(self):
@@ -499,7 +580,7 @@ class Weighter:
             raise ValueError("Primary physical distributions have not been set.")
 
         injectors = [
-            injector._Injector__injector
+            injector.engine
             if isinstance(injector, _PyInjector) else injector
             for injector in self.__injectors
         ]
@@ -514,11 +595,7 @@ class Weighter:
         primary_process.distributions = self.primary_physical_distributions
 
         # Copy weighting mode from the injector's primary process
-        inj0 = injectors[0]
-        if isinstance(inj0, _PyInjector):
-            inj0_cpp = inj0._Injector__injector
-        else:
-            inj0_cpp = inj0
+        inj0_cpp = injectors[0]
         if inj0_cpp is not None:
             primary_process.weighting_mode = inj0_cpp.GetPrimaryProcess().GetWeightingMode()
 

--- a/python/Weighter.py
+++ b/python/Weighter.py
@@ -71,10 +71,16 @@ class Weighter:
                      primary_interactions=..., primary_physical_distributions=...,
                      secondary_interactions=..., secondary_physical_distributions=...)
 
-        Spec form, positional injectors plus physical-side keywords, inheriting
-        detector/types/interactions from the injectors themselves::
+        Spec form inherits the first injector's detector, types, and vertex
+        physical models/distributions for the shared physical target::
 
-            Weighter(injector, primary_physical=[...], secondary_physical={...})
+            Weighter(injector)
+
+        ``primary_physical`` and ``secondary_physical`` replace the inherited
+        distributions, including when explicitly empty.
+
+        Injectors without Vertex specifications default to their sampling
+        models and no physical distributions.
 
         ``overrides`` (spec form only) is a dict of legacy field names
         (``detector_model``, ``primary_type``, ``primary_interactions``,
@@ -161,24 +167,29 @@ class Weighter:
 
     def __init_from_injectors(self, injectors, primary_physical,
                                secondary_physical, overrides):
-        """Populate fields by inheriting from the given injectors' processes."""
+        """Inherit the first injector's physical target, then apply overrides."""
         overrides = overrides or {}
 
         self.injectors = injectors
 
-        engine0 = injectors[0].engine if isinstance(injectors[0], _PyInjector) else injectors[0]
+        first = injectors[0]
+        engine0 = first.engine if isinstance(first, _PyInjector) else first
         primary_proc = engine0.GetPrimaryProcess()
+        primary_vertex = first.primary if isinstance(first, _PyInjector) else None
 
         self.__detector_model = overrides.get(
             "detector_model",
-            injectors[0].detector_model if isinstance(injectors[0], _PyInjector)
+            first.detector_model if isinstance(first, _PyInjector)
             else engine0.GetDetectorModel())
         self.__primary_type = overrides.get(
             "primary_type", primary_proc.primary_type)
-        self.__primary_interactions = overrides.get(
-            "primary_interactions",
+        primary_interactions = (
             list(primary_proc.interactions.GetCrossSections())
             + list(primary_proc.interactions.GetDecays()))
+        if primary_vertex is not None and primary_vertex.physical_interactions is not None:
+            primary_interactions = list(primary_vertex.physical_interactions)
+        self.__primary_interactions = overrides.get(
+            "primary_interactions", primary_interactions)
 
         secondary_interactions = overrides.get("secondary_interactions", None)
         if secondary_interactions is None:
@@ -187,12 +198,23 @@ class Weighter:
                 secondary_interactions[ptype] = (
                     list(sproc.interactions.GetCrossSections())
                     + list(sproc.interactions.GetDecays()))
+            if isinstance(first, _PyInjector):
+                for vertex in first.secondaries:
+                    if vertex.physical_interactions is not None:
+                        secondary_interactions[vertex._resolved_particle] = list(
+                            vertex.physical_interactions)
         self.__secondary_interactions = secondary_interactions
 
-        self.__primary_physical_distributions = (
-            list(primary_physical) if primary_physical is not None else [])
-        self.__secondary_physical_distributions = (
-            dict(secondary_physical) if secondary_physical is not None else {})
+        if primary_physical is None:
+            primary_physical = primary_vertex.physical if primary_vertex is not None else []
+        if secondary_physical is None:
+            secondary_physical = {
+                vertex._resolved_particle: list(vertex.physical)
+                for vertex in first.secondaries
+            } if isinstance(first, _PyInjector) else {}
+        self.__primary_physical_distributions = list(primary_physical)
+        self.__secondary_physical_distributions = {
+            ptype: list(dists) for ptype, dists in secondary_physical.items()}
 
     @property
     def injectors(self) -> List[_Injector]:
@@ -449,7 +471,7 @@ class Weighter:
         for injector in (self.__injectors or []):
             if isinstance(injector, _PyInjector):
                 try:
-                    injector._guard_serializable(_errors)
+                    injector._guard_serializable(_errors, for_weighter=True)
                 except _errors.NotSerializableError as exc:
                     offenders.extend("injector: " + o for o in exc.offenders)
         for interaction in self.__primary_interactions:
@@ -576,8 +598,6 @@ class Weighter:
             raise ValueError("Primary type has not been set.")
         if len(self.__primary_interactions) == 0:
             raise ValueError("Primary interactions have not been set.")
-        if len(self.__primary_physical_distributions) == 0:
-            raise ValueError("Primary physical distributions have not been set.")
 
         injectors = [
             injector.engine

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -73,7 +73,30 @@ from . import particles
 from . import dist
 from . import tune
 
-# ---- Model base classes + sampling closure ----
+# ---- Spec vocabulary ----
+from . import errors
+from . import channels
+from . import expand
+from .vertex import Vertex
+from ._directed import Directed
+from .generate import generate
+
+# Weighting-mode presets re-exported at the top level.
+Propagated = injection.VertexWeightingMode.Propagated
+Fixed = injection.VertexWeightingMode.Fixed
+
+# Deprecation aliases in this package should surface once by default; set
+# SIREN_STRICT=1 to escalate them to errors.
+import os as _os
+import warnings as _warnings
+_warnings.filterwarnings("default", category=DeprecationWarning,
+                         module=r"siren($|\.)")
+if _os.environ.get("SIREN_STRICT") == "1":
+    _warnings.filterwarnings("error", category=DeprecationWarning,
+                             module=r"siren($|\.)")
+del _os, _warnings
+
+# ---- Simulation and Results ----
 from .Simulation import Simulation
 from .Results import Results
 

--- a/python/errors.py
+++ b/python/errors.py
@@ -43,6 +43,14 @@ class NotSerializableError(RuntimeError):
         self.offenders = list(offenders) if offenders is not None else []
 
 
+class GenerationFailure(RuntimeError):
+    """Strict generation encountered a failure beyond a geometric miss."""
+
+    def __init__(self, message, report=None):
+        super().__init__(message)
+        self.report = report
+
+
 class InjectionShortfall(RuntimeError, UserWarning):
     """Generation produced fewer successes than requested.
 

--- a/python/generate.py
+++ b/python/generate.py
@@ -1,0 +1,26 @@
+"""One-call generation + weighting entry point.
+
+generate(injector, weighter, *, events, ...) drives the injector to `events`
+successful trees and weights them through the weighter, returning a Results
+snapshot of the trees and their weights.
+"""
+
+from __future__ import annotations
+
+from .Results import Results
+
+
+def generate(injector, weighter, *, events, on_shortfall="warn",
+             progress=None, min_efficiency=None):
+    """Generate `events` weighted trees.
+
+    Delegates generation to ``injector.generate`` (which counts successes and
+    honours ``on_shortfall``/``min_efficiency``), weights via
+    ``weighter.weight_all``, and returns a Results over the trees and weights.
+    """
+    trees = injector.generate(
+        events, on_shortfall=on_shortfall, progress=progress,
+        min_efficiency=min_efficiency)
+    weights = weighter.weight_all(trees)
+    gen_times = [0.0] * len(trees)
+    return Results(list(trees), list(weights), gen_times, weighter, injector)

--- a/python/generate.py
+++ b/python/generate.py
@@ -11,16 +11,16 @@ from .Results import Results
 
 
 def generate(injector, weighter, *, events, on_shortfall="warn",
-             progress=None, min_efficiency=None):
+             progress=None, min_efficiency=None, on_failure="retry"):
     """Generate `events` weighted trees.
 
     Delegates generation to ``injector.generate`` (which counts successes and
-    honours ``on_shortfall``/``min_efficiency``), weights via
+    honours ``on_shortfall``/``min_efficiency``/``on_failure``), weights via
     ``weighter.weight_all``, and returns a Results over the trees and weights.
     """
     trees = injector.generate(
         events, on_shortfall=on_shortfall, progress=progress,
-        min_efficiency=min_efficiency)
+        min_efficiency=min_efficiency, on_failure=on_failure)
     weights = weighter.weight_all(trees)
     gen_times = [0.0] * len(trees)
     return Results(list(trees), list(weights), gen_times, weighter, injector)

--- a/python/report.py
+++ b/python/report.py
@@ -1,0 +1,244 @@
+"""Rendering layer over the engine's failure ledger and weight breakdown.
+
+InjectionReport turns an Injector's FailureLedger into a readable attrition
+table with per-reason remedies; WeightBreakdown turns a Weighter's
+EventWeightBreakdown into a per-vertex weight decomposition that names the
+culprit vertex behind an inf/zero/NaN weight. Neither computes physics; both
+read structures the engine already produced.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict, List, Optional
+
+from . import dataclasses as _dataclasses
+
+
+def _reason_name(reason) -> str:
+    return getattr(reason, "name", str(reason))
+
+
+def _pdg_name(pdg: int) -> str:
+    """Human name for a PDG code, falling back to the integer."""
+    try:
+        return _dataclasses.ParticleType(int(pdg)).name
+    except (ValueError, TypeError):
+        return str(pdg)
+
+
+# One-line remedy per FailureReason. Keyed by the enum member name so a new
+# reason without a hint still renders (its name plus a generic line).
+_REASON_HINTS: Dict[str, str] = {
+    "NoTargetsOnPath":
+        "the sampled path crosses no interaction target; widen the vertex "
+        "distribution's region or check the detector materials",
+    "NoPathThroughVolume":
+        "the primary direction never enters the injection volume; check the "
+        "direction distribution and the volume placement",
+    "NoColumnDepthSolution":
+        "no column-depth solution along the path; the energy or geometry "
+        "leaves the vertex sampler with no root",
+    "KinematicallyForbidden":
+        "the sampled kinematics are below threshold; check masses and the "
+        "primary energy range",
+    "UnregisteredSecondaryType":
+        "a produced secondary has no registered Vertex; add a secondary "
+        "Vertex for it or prune it in the expand list",
+    "PrimaryVertexFailure":
+        "the primary vertex could not be sampled; inspect the primary "
+        "position/energy distributions",
+    "TopLevelCatch":
+        "an unclassified failure escaped to the top level; inspect the "
+        "exemplar message",
+    "Unspecified":
+        "failure reason not tagged; inspect the exemplar message",
+}
+
+
+class VertexAttrition:
+    """One (depth, particle, reason) bucket of injection failures."""
+
+    __slots__ = ("depth", "pdg", "reason", "count", "exemplar")
+
+    def __init__(self, depth: int, pdg: int, reason, count: int, exemplar: str):
+        self.depth = depth
+        self.pdg = pdg
+        self.reason = reason
+        self.count = count
+        self.exemplar = exemplar
+
+    @property
+    def reason_name(self) -> str:
+        return _reason_name(self.reason)
+
+    @property
+    def particle(self) -> str:
+        return _pdg_name(self.pdg)
+
+    @property
+    def hint(self) -> str:
+        return _REASON_HINTS.get(self.reason_name, "inspect the exemplar message")
+
+    def __repr__(self):
+        return ("VertexAttrition(depth={} particle={} reason={} count={})"
+                .format(self.depth, self.particle, self.reason_name, self.count))
+
+
+class InjectionReport:
+    """Readable view of an injection run's outcome.
+
+    attempts/successes are the realized counts; by_vertex is the attrition
+    breakdown; last_failed_tree is the most recent partial tree on a primary
+    failure (may be empty). dominant() names the reason that lost the most
+    attempts.
+    """
+
+    __slots__ = ("attempts", "successes", "by_vertex", "last_failed_tree")
+
+    def __init__(self, attempts: int, successes: int,
+                 by_vertex: List[VertexAttrition],
+                 last_failed_tree=None):
+        self.attempts = attempts
+        self.successes = successes
+        self.by_vertex = list(by_vertex)
+        self.last_failed_tree = last_failed_tree
+
+    @classmethod
+    def from_ledger(cls, ledger, *, attempts: int, successes: int,
+                    last_failed_tree=None) -> "InjectionReport":
+        """Build a report from an engine FailureLedger.
+
+        ledger.entries() maps (depth, parent_pdg, FailureReason) to
+        (count, exemplar).
+        """
+        buckets = []
+        for (depth, pdg, reason), (count, exemplar) in ledger.entries().items():
+            buckets.append(VertexAttrition(depth, pdg, reason, count, exemplar))
+        buckets.sort(key=lambda b: b.count, reverse=True)
+        return cls(attempts, successes, buckets, last_failed_tree)
+
+    @property
+    def failures(self) -> int:
+        return sum(b.count for b in self.by_vertex)
+
+    @property
+    def efficiency(self) -> float:
+        if self.attempts <= 0:
+            return float("nan")
+        return self.successes / self.attempts
+
+    def dominant(self) -> Optional[VertexAttrition]:
+        """The attrition bucket that lost the most attempts, or None."""
+        if not self.by_vertex:
+            return None
+        return max(self.by_vertex, key=lambda b: b.count)
+
+    def __str__(self):
+        lines = []
+        eff = self.efficiency
+        eff_str = "{:.1%}".format(eff) if math.isfinite(eff) else "n/a"
+        lines.append("InjectionReport: {}/{} succeeded (efficiency {})".format(
+            self.successes, self.attempts, eff_str))
+        if not self.by_vertex:
+            lines.append("  no failures recorded")
+            return "\n".join(lines)
+        lines.append("  {:<6} {:<14} {:<26} {:>8}".format(
+            "depth", "particle", "reason", "count"))
+        for b in self.by_vertex:
+            lines.append("  {:<6} {:<14} {:<26} {:>8}".format(
+                b.depth, b.particle, b.reason_name, b.count))
+        dom = self.dominant()
+        if dom is not None:
+            lines.append("  dominant: {} ({}x) -- {}".format(
+                dom.reason_name, dom.count, dom.hint))
+        return "\n".join(lines)
+
+
+class VertexWeightLine:
+    """One vertex's factors within a weight breakdown."""
+
+    __slots__ = ("depth", "pdg", "generation", "physical",
+                 "channel_densities", "cancelled", "flags")
+
+    def __init__(self, depth, pdg, generation, physical,
+                 channel_densities, cancelled, flags):
+        self.depth = depth
+        self.pdg = pdg
+        self.generation = generation
+        self.physical = physical
+        self.channel_densities = dict(channel_densities)
+        self.cancelled = list(cancelled)
+        self.flags = list(flags)
+
+    @property
+    def particle(self) -> str:
+        return _pdg_name(self.pdg)
+
+    @property
+    def is_ok(self) -> bool:
+        return (math.isfinite(self.physical) and self.physical > 0.0
+                and math.isfinite(self.generation) and self.generation > 0.0)
+
+    def __repr__(self):
+        flag = "" if self.is_ok else " !!!"
+        return ("VertexWeightLine(d={} {} gen={:.3e} phys={:.3e}{})".format(
+            self.depth, self.particle, self.generation, self.physical, flag))
+
+
+class WeightBreakdown:
+    """Per-vertex decomposition of one event's weight.
+
+    total is the event weight; vertices are the per-vertex factor lines.
+    culprit() names the first vertex whose factors explain a non-finite or
+    zero total.
+    """
+
+    __slots__ = ("total", "vertices")
+
+    def __init__(self, total: float, vertices: List[VertexWeightLine]):
+        self.total = total
+        self.vertices = list(vertices)
+
+    @classmethod
+    def from_engine(cls, breakdown) -> "WeightBreakdown":
+        """Build from an engine EventWeightBreakdown struct."""
+        lines = []
+        for v in breakdown.vertices:
+            lines.append(VertexWeightLine(
+                v.depth, v.vertex_pdg, v.generation, v.physical,
+                v.channel_densities, v.cancelled, v.flags))
+        return cls(breakdown.total, lines)
+
+    def culprit(self) -> Optional[VertexWeightLine]:
+        """The first vertex whose factors explain a bad total, or None."""
+        if math.isfinite(self.total) and self.total > 0.0:
+            return None
+        for v in self.vertices:
+            if not v.is_ok:
+                return v
+        return None
+
+    def __str__(self):
+        ok = math.isfinite(self.total) and self.total > 0.0
+        lines = ["WeightBreakdown: total={:.6e}{}".format(
+            self.total, "" if ok else " (unusable)")]
+        for v in self.vertices:
+            line = "  d={} {:<12} gen={:.3e} phys={:.3e}".format(
+                v.depth, v.particle, v.generation, v.physical)
+            extras = []
+            if v.cancelled:
+                extras.append("cancelled=" + ",".join(v.cancelled))
+            if v.flags:
+                extras.append("flags=" + ";".join(v.flags))
+            if not v.is_ok:
+                extras.append("!!!")
+            if extras:
+                line += "  [" + " ".join(extras) + "]"
+            lines.append(line)
+        culprit = self.culprit()
+        if culprit is not None:
+            lines.append("  culprit: d={} {} ({})".format(
+                culprit.depth, culprit.particle,
+                ";".join(culprit.flags) or "no positive support"))
+        return "\n".join(lines)

--- a/tests/python/test_density_breakdown.py
+++ b/tests/python/test_density_breakdown.py
@@ -65,15 +65,18 @@ def test_density_breakdown_sums_to_density():
 
 
 # --------------------------------------------------------------------------- #
-# VertexWeightFactors.channel_densities contract, as observed through a real  #
-# assembled Injector/Weighter pair (not the bare MultiChannelPhaseSpace above).#
+# VertexWeightFactors.channel_densities/cancelled contract, as observed        #
+# through a real assembled Injector/Weighter pair (not the bare                #
+# MultiChannelPhaseSpace above).                                              #
 #                                                                              #
-# ComputeVertexFactors (Weighter.cxx) never writes into channel_densities on   #
-# any current code path: the DummyCrossSection assembly below has no vertex   #
-# backed by a MultiChannelPhaseSpace, so the field stays at its default-       #
-# constructed empty map for every vertex.  This test pins that observed        #
-# current contract -- a dict on every vertex, empty here -- rather than        #
-# asserting non-empty population that this assembly never produces.           #
+# ComputeVertexFactors (Weighter.cxx) always writes channel_densities and      #
+# cancelled on the diagnostics path (EventWeightWithBreakdown): the former is  #
+# keyed from the injection process's MultiChannelPhaseSpace.DensityBreakdown  #
+# when one is attached for the vertex's signature, and the latter lists the   #
+# distribution Name()s shared by value between the injection and physical     #
+# distribution lists. The DummyCrossSection assembly below attaches no phase  #
+# space and shares no value-equal distributions, so both fields are wired but #
+# stay empty for every vertex in this assembly specifically.                  #
 # --------------------------------------------------------------------------- #
 
 def _skip_unless_ccm_data():
@@ -144,12 +147,8 @@ def _build_chain(detector_model, n_inject, seed):
     return inj, weighter, keepalive
 
 
-def test_vertex_channel_densities_is_an_empty_dict_for_this_assembly():
-    """VertexWeightFactors.channel_densities is a dict on every vertex and stays
-    empty for the DummyCrossSection assembly, which has no
-    MultiChannelPhaseSpace-backed vertex. The finiteness check and the final
-    assertion form a tripwire: if a future change starts populating the map,
-    this test fails so the check can be tightened to the populated values."""
+def test_vertex_channel_densities_and_cancelled_are_wired_but_empty_for_this_assembly():
+    """channel_densities/cancelled are wired but empty for a vertex with no attached mixture and no value-shared distributions."""
     _skip_unless_ccm_data()
     detector_model = _load_ccm_detector()
     inj, weighter, _keepalive = _build_chain(detector_model, 2000, 2468)
@@ -169,21 +168,83 @@ def test_vertex_channel_densities_is_an_empty_dict_for_this_assembly():
         events.append(ev)
     assert len(events) == 20
 
-    saw_nonempty = False
     for ev in events:
         bd = weighter.EventWeightWithBreakdown(ev)
         for v in bd.vertices:
             cd = v.channel_densities
+            cancelled = v.cancelled
             assert isinstance(cd, dict)
-            if cd:
-                saw_nonempty = True
-                values = list(cd.values())
-                assert all(math.isfinite(x) for x in values)
+            assert isinstance(cancelled, list)
+            assert all(math.isfinite(x) for x in cd.values())
+            # This assembly attaches no MultiChannelPhaseSpace and shares no
+            # value-equal distributions between injection and physical, so
+            # both fields stay empty for every vertex here.
+            assert cd == {}
+            assert cancelled == []
 
-    # Documents the current, observed contract for this assembly: the
-    # DummyCrossSection chain has no MultiChannelPhaseSpace-backed vertex, so
-    # ComputeVertexFactors never populates channel_densities.
-    assert saw_nonempty is False, (
-        "channel_densities was populated by this assembly; the "
-        "'observed empty' contract this test documents has changed and the "
-        "assertions above should be tightened to check the populated values.")
+
+def test_channel_densities_contract_matches_density_breakdown():
+    """channel_densities entries are the mixture's DensityBreakdown, keyed channel[i]."""
+    target = siren.geometry.Box(
+        siren.geometry.Placement(siren.math.Vector3D(0.0, 0.0, 2.0)),
+        1.0, 1.0, 1.0)
+    iso = siren.injection.Isotropic2BodyChannel(0)
+    directed = siren.injection.DetectorDirected2BodyChannel(target, 0)
+    mc = siren.injection.MultiChannelPhaseSpace()
+    mc.channels = [iso, directed]
+    mc.weights = [0.3, 0.7]
+
+    rng = siren.utilities.SIREN_random(11)
+    r = _make_record()
+    mc.Sample(rng, None, r)
+
+    bd = mc.DensityBreakdown(None, r)
+    g = mc.Density(None, r)
+    assert len(bd) == 2
+    assert all(math.isfinite(x) for x in bd)
+    assert sum(bd) == g
+
+    channel_densities = {"channel[" + str(i) + "]": bd[i] for i in range(len(bd))}
+    assert list(channel_densities.keys()) == ["channel[0]", "channel[1]"]
+    assert all(math.isfinite(x) for x in channel_densities.values())
+    assert sum(channel_densities.values()) == g
+
+
+def test_vertex_channel_densities_report_their_common_convention():
+    """Every populated diagnostic density map identifies its common measure."""
+    _skip_unless_ccm_data()
+    detector_model = _load_ccm_detector()
+    inj, weighter, keepalive = _build_chain(detector_model, 2000, 97531)
+
+    event = None
+    for _ in range(2000):
+        try:
+            candidate = inj.GenerateEvent()
+        except RuntimeError as err:
+            if "maximum number of injection attempts" not in str(err):
+                raise
+            break
+        if len(candidate.tree) > 0:
+            event = candidate
+            break
+    assert event is not None
+
+    # Attach the diagnostic phase space after generation. This exercises the
+    # weighting/reporting path without asking the physical adapter to resample
+    # DummyCrossSection's synthetic Nucleon secondary (which has no mass-map
+    # entry).
+    xs, _, _, _, primary_inj, *_ = keepalive
+    signature = event.tree[0].record.signature
+    channel = injection.PhysicalCrossSectionChannel(xs, signature)
+    mixture = injection.MultiChannelPhaseSpace()
+    mixture.channels = [channel]
+    mixture.weights = [1.0]
+    primary_inj.SetPhaseSpace(signature, mixture)
+
+    breakdown = weighter.EventWeightWithBreakdown(event)
+    populated = [vertex for vertex in breakdown.vertices
+                 if vertex.channel_densities]
+    assert populated
+    for vertex in populated:
+        assert vertex.channel_density_topology == injection.PhaseSpaceTopology.Scatter2to2
+        assert vertex.channel_density_measure == injection.PhaseSpaceMeasure.BjorkenXY()

--- a/tests/python/test_failure_report.py
+++ b/tests/python/test_failure_report.py
@@ -162,3 +162,53 @@ def test_ledger_clear_resets_to_empty():
 
     inj.GetFailureLedger().Clear()
     assert inj.GetFailureLedger().entries() == {}
+
+
+# --------------------------------------------------------------------------- #
+# (d) The rendered InjectionReport over the ledger.                           #
+# --------------------------------------------------------------------------- #
+
+def test_injection_report_renders_table_and_dominant():
+    """InjectionReport.from_ledger renders an attrition table and a dominant()."""
+    from siren.report import InjectionReport
+
+    inj, _keepalive = _make_forced_failure_injector(n_inject=4)
+    for _ in range(4):
+        inj.GenerateEvent()
+
+    report = InjectionReport.from_ledger(
+        inj.GetFailureLedger(),
+        attempts=inj.InjectionAttempts(),
+        successes=inj.InjectedEvents(),
+        last_failed_tree=inj.GetLastFailedTree())
+
+    text = str(report)
+    assert "InjectionReport" in text
+    assert "NoTargetsOnPath" in text
+    assert "count" in text
+
+    dominant = report.dominant()
+    assert dominant is not None
+    assert dominant.reason_name == "NoTargetsOnPath"
+    assert dominant.count == 4
+    assert dominant.hint  # a non-empty one-line remedy
+
+
+def test_injection_report_efficiency_and_particle_name():
+    """The report exposes efficiency and a resolved particle name per bucket."""
+    from siren.report import InjectionReport
+
+    inj, _keepalive = _make_forced_failure_injector(n_inject=3)
+    for _ in range(3):
+        inj.GenerateEvent()
+
+    report = InjectionReport.from_ledger(
+        inj.GetFailureLedger(),
+        attempts=inj.InjectionAttempts(),
+        successes=inj.InjectedEvents())
+
+    assert report.successes == 0
+    assert report.efficiency == 0.0
+    bucket = report.dominant()
+    # The parent PDG (14, NuMu) resolves to a readable particle name.
+    assert bucket.particle != str(bucket.pdg) or bucket.pdg == 14

--- a/tests/python/test_failure_report.py
+++ b/tests/python/test_failure_report.py
@@ -342,3 +342,53 @@ def test_native_sampling_failures_preserve_reason_and_attempt_accounting(depth, 
     inj.ResetInjectedEvents(1)
     assert inj.EventsToInject() == 1
     assert inj.InjectionAttempts() == inj.InjectedEvents() == inj.FailedEvents() == 0
+
+
+# --------------------------------------------------------------------------- #
+# (d) The rendered InjectionReport over the ledger.                           #
+# --------------------------------------------------------------------------- #
+
+def test_injection_report_renders_table_and_dominant():
+    """InjectionReport.from_ledger renders an attrition table and a dominant()."""
+    from siren.report import InjectionReport
+
+    inj, _keepalive = _make_forced_failure_injector(n_inject=4)
+    for _ in range(4):
+        inj.GenerateEvent()
+
+    report = InjectionReport.from_ledger(
+        inj.GetFailureLedger(),
+        attempts=inj.InjectionAttempts(),
+        successes=inj.InjectedEvents(),
+        last_failed_tree=inj.GetLastFailedTree())
+
+    text = str(report)
+    assert "InjectionReport" in text
+    assert "NoTargetsOnPath" in text
+    assert "count" in text
+
+    dominant = report.dominant()
+    assert dominant is not None
+    assert dominant.reason_name == "NoTargetsOnPath"
+    assert dominant.count == 4
+    assert dominant.hint  # a non-empty one-line remedy
+
+
+def test_injection_report_efficiency_and_particle_name():
+    """The report exposes efficiency and a resolved particle name per bucket."""
+    from siren.report import InjectionReport
+
+    inj, _keepalive = _make_forced_failure_injector(n_inject=3)
+    for _ in range(3):
+        inj.GenerateEvent()
+
+    report = InjectionReport.from_ledger(
+        inj.GetFailureLedger(),
+        attempts=inj.InjectionAttempts(),
+        successes=inj.InjectedEvents())
+
+    assert report.successes == 0
+    assert report.efficiency == 0.0
+    bucket = report.dominant()
+    # The parent PDG (14, NuMu) resolves to a readable particle name.
+    assert bucket.particle != str(bucket.pdg) or bucket.pdg == 14

--- a/tests/python/test_generation_policy.py
+++ b/tests/python/test_generation_policy.py
@@ -1,0 +1,172 @@
+"""Strict generation rejects numerical failures at the failing attempt."""
+
+import math
+
+import pytest
+
+import siren
+from siren import dataclasses as dc, distributions as d, injection, interactions
+from siren.errors import GenerationFailure, InjectionShortfall, WeightCalculationError
+from test_failure_report import _FixedPrimary, _FixedSecondary, _ChainDecay
+from test_injector_api import _forced_failure_injector
+
+
+class _Source(_FixedPrimary):
+    def RequiredVariables(self):
+        return set()
+
+    def SetVariables(self):
+        dv = d.DistributionVariable
+        return {dv.PrimaryEnergy, dv.PrimaryDirection, dv.InitialPosition,
+                dv.InteractionVertex}
+
+
+class _Decay(_ChainDecay):
+    def DifferentialDecayWidth(self, record):
+        return 1.0
+
+    def FinalStateProbability(self, record):
+        return 1.0
+
+
+def _native_sampler(depth, source=None):
+    source = _Source() if source is None else source
+    types = [dc.ParticleType.NuMu, dc.ParticleType.NuE, dc.ParticleType.NuTau,
+             dc.ParticleType.Gamma]
+    models = [_Decay(types[i], types[i + 1], source) for i in range(depth + 1)]
+    target = siren.geometry.Sphere(
+        siren.geometry.Placement(siren.math.Vector3D(0, 0, 100)), 1.0, 0.0)
+    mixture = injection.MultiChannelPhaseSpace([
+        injection.DetectorDirected2BodyChannel(target, 0, injection.DirectedMode.Cone)])
+    phase_spaces = {models[-1].signature: mixture}
+    inj = injection.Injector(
+        detector=siren.detector.DetectorModel(), events=2, max_attempts=3, seed=331663,
+        primary_type=types[0], primary_interactions=[models[0]],
+        primary_injection_distributions=[source],
+        primary_phase_spaces=phase_spaces if depth == 0 else {},
+        secondary_interactions={types[i]: [models[i]] for i in range(1, depth + 1)},
+        secondary_injection_distributions={types[i]: [_FixedSecondary()]
+                                           for i in range(1, depth + 1)},
+        secondary_phase_spaces={types[depth]: phase_spaces} if depth else {},
+        stopping_condition=lambda tree, parent, index: False)
+    return inj, source
+
+
+@pytest.mark.parametrize("depth", [0, 1, 2])
+@pytest.mark.parametrize("shortfall", ["warn", "raise", "ignore"])
+def test_strict_sampler_failure_stops_immediately_with_report(depth, shortfall):
+    inj, source = _native_sampler(depth)
+    with pytest.raises(GenerationFailure, match="SamplingFailure") as exc:
+        inj.generate(on_failure="raise", on_shortfall=shortfall)
+    report = exc.value.report
+    assert report.attempts == inj.engine.InjectionAttempts() == 1
+    assert report.successes == 0
+    assert report.by_vertex[0].reason == injection.FailureReason.SamplingFailure
+    assert report.by_vertex[0].depth == depth
+    assert len(report.last_failed_tree.tree) == max(1, depth)
+    # A new run resets the ledger and succeeds with valid on-shell inputs.
+    source.momentum = [10.0, 0.0, 0.0, math.sqrt(96.0)]
+    trees = inj.generate(on_failure="raise", on_shortfall="raise")
+    assert len(trees) == inj.engine.InjectionAttempts() == 2
+    assert inj.report().by_vertex == []
+
+
+def test_default_retry_policy_keeps_existing_behavior():
+    inj, _ = _native_sampler(0)
+    assert inj.generate(on_shortfall="ignore") == []
+    assert inj.report().attempts == 3
+    assert inj.report().dominant().reason == injection.FailureReason.SamplingFailure
+
+
+def test_strict_policy_rejects_closed_kinematics_conservatively():
+    inj, source = _native_sampler(0)
+    source.mass = 0.9
+    source.momentum = [10.0, 0.0, 0.0, math.sqrt(100.0 - 0.9**2)]
+    with pytest.raises(GenerationFailure, match="KinematicallyForbidden"):
+        inj.generate(on_failure="raise")
+    assert inj.engine.InjectionAttempts() == 1
+
+
+def test_strict_geometric_misses_use_attempt_budget_and_shortfall_policy():
+    inj = _forced_failure_injector(events=2, max_attempts=4)
+    with pytest.raises(InjectionShortfall) as exc:
+        inj.generate(on_failure="raise", on_shortfall="raise")
+    assert exc.value.report.attempts == inj.engine.InjectionAttempts() == 4
+    assert inj.engine.FailedEvents() == 4
+    assert exc.value.report.dominant().reason == injection.FailureReason.NoTargetsOnPath
+
+
+def test_invalid_policy_does_not_reset_an_existing_run():
+    inj = _forced_failure_injector(events=1, max_attempts=2)
+    inj.generate(on_shortfall="ignore")
+    with pytest.raises(ValueError, match="on_failure"):
+        inj.generate(on_failure="typo")
+    assert inj.engine.InjectionAttempts() == 2
+
+
+def test_generate_facade_propagates_strict_failure_before_weighting():
+    class NoWeighting:
+        def weight_all(self, trees):
+            pytest.fail("weighting must not run after a strict failure")
+    inj, _ = _native_sampler(1)
+    with pytest.raises(GenerationFailure, match="SamplingFailure"):
+        siren.generate(inj, NoWeighting(), events=1, on_failure="raise")
+
+
+def test_generate_facade_propagates_weight_errors():
+    class BrokenWeighter:
+        def weight_all(self, trees):
+            raise WeightCalculationError("physical density undefined")
+    inj, source = _native_sampler(0)
+    source.momentum = [10.0, 0.0, 0.0, math.sqrt(96.0)]
+    with pytest.raises(WeightCalculationError, match="physical density undefined"):
+        siren.generate(inj, BrokenWeighter(), events=1, on_failure="raise")
+    assert inj.engine.InjectionAttempts() == 1
+
+
+def test_strict_and_retry_runs_preserve_geometric_misses_and_event_weights():
+    from test_weighter_inheritance import _injector
+    strict, retry = _injector(), _injector()
+    strict_trees = strict.generate(5, on_failure="raise", on_shortfall="raise")
+    retry_trees = retry.generate(5, on_failure="retry", on_shortfall="raise")
+    assert strict.engine.InjectionAttempts() == retry.engine.InjectionAttempts()
+    assert strict.engine.FailedEvents() == retry.engine.FailedEvents()
+    for a, b in zip(strict_trees, retry_trees):
+        assert a.tree[0].record.primary_momentum == b.tree[0].record.primary_momentum
+        assert a.tree[0].record.interaction_vertex == b.tree[0].record.interaction_vertex
+    import numpy as np
+    np.testing.assert_array_equal(injection.Weighter(strict).weight_all(strict_trees),
+                                  injection.Weighter(retry).weight_all(retry_trees))
+
+
+def test_strict_secondary_zero_length_path_uses_attempt_budget():
+    inj, source = _native_sampler(1)
+    source.momentum = [10.0, 0.0, 0.0, math.sqrt(96.0)]
+    inj.secondary_injection_distributions = {
+        dc.ParticleType.NuE: [d.SecondaryBoundedVertexDistribution(0.0)]}
+    inj.secondary_phase_spaces = {}
+    assert inj.generate(1, on_failure="raise", on_shortfall="ignore") == []
+    assert inj.engine.InjectedEvents() == 0
+    assert inj.engine.InjectionAttempts() == inj.engine.FailedEvents() == 3
+    assert inj.report().dominant().reason == injection.FailureReason.NoPathThroughVolume
+
+
+def test_strict_generation_propagates_unexpected_python_errors():
+    class BrokenSource(_Source):
+        def Sample(self, *args):
+            raise RuntimeError("source data corrupt")
+
+    inj, _ = _native_sampler(0, BrokenSource())
+    with pytest.raises(RuntimeError, match="source data corrupt"):
+        inj.generate(on_failure="raise")
+
+
+def test_generate_facade_keeps_zero_weight_events():
+    from test_weighter_inheritance import _injector
+    inj = _injector(chain=False)
+    inj.primary.physical = [d.NormalizationConstant(0.0)]
+    result = siren.generate(inj, injection.Weighter(inj), events=2,
+                            on_failure="raise", on_shortfall="raise")
+    assert len(result) == 2
+    assert list(result.weights) == [0.0, 0.0]
+    assert inj.engine.InjectedEvents() == 2

--- a/tests/python/test_hepmc3_darknews.py
+++ b/tests/python/test_hepmc3_darknews.py
@@ -100,6 +100,7 @@ def _build_darknews_ccm(events_to_inject=2):
     injector.primary_injection_distributions = primary_injection_distributions
     injector.secondary_interactions = secondary_processes
     injector.secondary_injection_distributions = secondary_injection_distributions
+    injector.stopping_condition = lambda tree, datum, i: True
 
     events, gen_times = GenerateEvents(injector)
 

--- a/tests/python/test_injector_api.py
+++ b/tests/python/test_injector_api.py
@@ -1,0 +1,651 @@
+"""Layer-2 Injector: generate() success counting, shortfall policy, reset,
+save guard, positional-Box warning, and legacy __iter__ semantics.
+
+Data-free where possible; anything needing detector data files skips cleanly.
+"""
+
+import os
+import pickle
+import warnings
+
+import pytest
+
+import siren
+from siren import dataclasses as dc
+from siren import injection
+from siren import interactions
+from siren import distributions
+from siren import detector
+from siren import math as smath
+from siren import utilities
+from siren import _util
+
+_NuMu = dc.Particle.ParticleType.NuMu
+
+
+def _skip_unless_ccm_data():
+    try:
+        det_dir = _util.get_detector_model_path("CCM")
+    except ValueError as e:
+        pytest.skip("CCM detector model path unavailable: {}".format(e))
+    missing = [p for p in (os.path.join(det_dir, "materials.dat"),
+                           os.path.join(det_dir, "densities.dat"))
+               if not os.path.exists(p)]
+    if missing:
+        pytest.skip("CCM detector data missing: " + ", ".join(missing))
+    return det_dir
+
+
+def _load_ccm_detector():
+    dm = detector.DetectorModel()
+    det_dir = _util.get_detector_model_path("CCM")
+    dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+    dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    return dm
+
+
+def _distributions(max_distance):
+    return [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(
+            smath.Vector3D(0, 0, 0), max_distance),
+    ]
+
+
+def _working_injector(events=5, seed=11, max_distance=25.0, max_attempts=None):
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj = injection.Injector(
+        detector=dm,
+        primary=None,
+        number_of_events=events,
+        seed=seed,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(max_distance),
+        max_attempts=max_attempts,
+    )
+    return inj
+
+
+def _forced_failure_injector(events=5, seed=11, max_attempts=None):
+    # A bare detector plus max_distance=0 makes every path miss its target,
+    # so every attempt fails with NoTargetsOnPath -- no data files needed.
+    dm = detector.DetectorModel()
+    inj = injection.Injector(
+        detector=dm,
+        number_of_events=events,
+        seed=seed,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(0.0),
+        max_attempts=max_attempts,
+    )
+    return inj
+
+
+def _depth_ge_1(tree, datum, i):
+    """Expand one chain level. Defined at module scope so pickle can carry it
+    by reference (a lambda would not survive the pickle state tuple)."""
+    return datum.depth(tree) >= 1
+
+
+def _chain_injector(events=20, seed=7, max_attempts=8000):
+    """A NuMu -> NuMu chain (DummyCrossSection at both vertices) whose stopping
+    condition expands one secondary level, mirroring the raw _build_chain in
+    test_density_breakdown. Uses CCM detector data; skips cleanly without it."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    return injection.Injector(
+        detector=dm,
+        number_of_events=events,
+        seed=seed,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(25.0),
+        secondary_interactions={_NuMu: [interactions.DummyCrossSection()]},
+        secondary_injection_distributions={
+            _NuMu: [distributions.SecondaryPhysicalVertexDistribution()]},
+        stopping_condition=_depth_ge_1,
+        max_attempts=max_attempts,
+    )
+
+
+# ------------------------------------------------------------------ #
+#  generate() counts successes                                        #
+# ------------------------------------------------------------------ #
+
+def test_generate_counts_successes_not_attempts():
+    """generate(N) returns exactly N non-empty trees."""
+    inj = _working_injector(events=10)
+    trees = inj.generate(10, on_shortfall="raise")
+    assert len(trees) == 10
+    assert all(len(t.tree) > 0 for t in trees)
+
+
+def test_generate_default_events_uses_configured_count():
+    """generate() with no argument uses the configured event count."""
+    inj = _working_injector(events=4)
+    trees = inj.generate(on_shortfall="raise")
+    assert len(trees) == 4
+
+
+# ------------------------------------------------------------------ #
+#  on_shortfall triple                                                #
+# ------------------------------------------------------------------ #
+
+def test_on_shortfall_raise():
+    """A shortfall with on_shortfall='raise' raises InjectionShortfall."""
+    inj = _forced_failure_injector(events=3, max_attempts=20)
+    with pytest.raises(siren.errors.InjectionShortfall) as exc:
+        inj.generate(3, on_shortfall="raise")
+    assert exc.value.report is not None
+    assert exc.value.report.successes == 0
+
+
+def test_on_shortfall_warn():
+    """A shortfall with on_shortfall='warn' warns and returns what succeeded."""
+    inj = _forced_failure_injector(events=3, max_attempts=20)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        trees = inj.generate(3, on_shortfall="warn")
+    assert len(trees) == 0
+    assert any(isinstance(x.message, siren.errors.InjectionShortfall) for x in w)
+
+
+def test_on_shortfall_ignore():
+    """A shortfall with on_shortfall='ignore' is silent."""
+    inj = _forced_failure_injector(events=3, max_attempts=20)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        trees = inj.generate(3, on_shortfall="ignore")
+    assert len(trees) == 0
+
+
+# ------------------------------------------------------------------ #
+#  min_efficiency early abort                                         #
+# ------------------------------------------------------------------ #
+
+def test_min_efficiency_early_abort_raises_with_report():
+    """Efficiency below min_efficiency aborts with an InjectionShortfall report."""
+    inj = _forced_failure_injector(events=100, max_attempts=100000)
+    with pytest.raises(siren.errors.InjectionShortfall) as exc:
+        inj.generate(100, on_shortfall="raise", min_efficiency=0.5)
+    assert exc.value.report is not None
+    assert exc.value.report.dominant() is not None
+
+
+# ------------------------------------------------------------------ #
+#  reset / reuse                                                      #
+# ------------------------------------------------------------------ #
+
+def test_reset_allows_reuse():
+    """reset() clears counters so a second generate() starts fresh."""
+    inj = _working_injector(events=5)
+    first = inj.generate(5, on_shortfall="raise")
+    assert len(first) == 5
+    inj.reset()
+    assert inj.injected_events == 0
+    second = inj.generate(5, on_shortfall="raise")
+    assert len(second) == 5
+
+
+# ------------------------------------------------------------------ #
+#  typo'd secondary dict key raises                                   #
+# ------------------------------------------------------------------ #
+
+def test_typo_secondary_key_raises():
+    """A secondary key present in one dict but not the interactions dict raises."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    xs = interactions.DummyCrossSection()
+    inj = injection.Injector(
+        detector=dm,
+        number_of_events=2,
+        seed=1,
+        primary_type=_NuMu,
+        primary_interactions=[xs],
+        primary_injection_distributions=_distributions(25.0),
+        secondary_interactions={_NuMu: [interactions.DummyCrossSection()]},
+        secondary_injection_distributions={_NuMu: [distributions.SecondaryPhysicalVertexDistribution()]},
+        secondary_weighting_modes={dc.Particle.ParticleType.NuE: injection.VertexWeightingMode.Fixed()},
+    )
+    with pytest.raises((siren.errors.ConfigurationError, ValueError)):
+        inj.generate(2, on_shortfall="ignore")
+
+
+# ------------------------------------------------------------------ #
+#  positional Box warns but still constructs                          #
+# ------------------------------------------------------------------ #
+
+def test_positional_box_warns_and_constructs():
+    """Box(x, y, z) emits a DeprecationWarning and still builds a box."""
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        box = siren.geometry.Box(1.0, 2.0, 3.0)
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
+    assert box.X == 1.0 and box.Y == 2.0 and box.Z == 3.0
+
+
+def test_widths_center_box_places_at_center():
+    """Box(widths=..., center=...) places the box at the given center."""
+    box = siren.geometry.Box(widths=(1.0, 1.0, 1.0), center=(0.0, 0.0, 5.0))
+    assert box.IsInside(siren.math.Vector3D(0, 0, 5))
+    assert not box.IsInside(siren.math.Vector3D(0, 0, 0))
+
+
+# ------------------------------------------------------------------ #
+#  __iter__ legacy semantics                                          #
+# ------------------------------------------------------------------ #
+
+def test_iter_warns_and_yields_attempt_count():
+    """__iter__ warns and yields exactly number_of_events raw attempts."""
+    inj = _working_injector(events=4)
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        events = list(inj)
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
+    assert len(events) == 4
+
+
+# ------------------------------------------------------------------ #
+#  save() round-trip guard                                            #
+# ------------------------------------------------------------------ #
+
+def test_save_on_fixed_mode_succeeds(tmp_path):
+    """save() archives a Fixed weighting mode with the process instead of
+    refusing it; the reloaded injector carries the same mode."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj = injection.Injector(
+        detector=dm,
+        number_of_events=2,
+        seed=1,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(25.0),
+        primary_weighting_mode=injection.VertexWeightingMode.Fixed(),
+    )
+    path = str(tmp_path / "inj")
+    inj.save(path)   # no NotSerializableError: the mode rides with the process
+    loaded = injection.Injector.load(path)
+    assert loaded.engine.GetPrimaryProcess().GetWeightingMode() == (
+        injection.VertexWeightingMode.Fixed())
+
+
+def test_report_is_rendered_after_failures():
+    """report() renders an attrition table with a dominant reason."""
+    inj = _forced_failure_injector(events=3, max_attempts=10)
+    inj.generate(3, on_shortfall="ignore")
+    report = inj.report()
+    text = str(report)
+    assert "InjectionReport" in text
+    assert report.dominant() is not None
+    assert report.dominant().reason_name == "NoTargetsOnPath"
+
+
+# ------------------------------------------------------------------ #
+#  Secondary trampoline serialization guard                           #
+# ------------------------------------------------------------------ #
+
+class _PySecondaryCrossSection(interactions.CrossSection):
+    """Data-free Python-subclassed CrossSection (a non-serializable trampoline)."""
+
+    def __init__(self):
+        interactions.CrossSection.__init__(self)
+
+    def TotalCrossSection(self, *args, **kwargs):
+        return 1.0
+
+    def DifferentialCrossSection(self, *args):
+        return 1.0
+
+    def InteractionThreshold(self, *args):
+        return 0.0
+
+    def SampleFinalState(self, *args):
+        pass
+
+    def GetPossibleTargets(self):
+        return [siren.particles.Nucleon]
+
+    def GetPossibleTargetsFromPrimary(self, primary_type):
+        return [siren.particles.Nucleon]
+
+    def GetPossiblePrimaries(self):
+        return [_NuMu]
+
+    def GetPossibleSignatures(self):
+        sig = dc.InteractionSignature()
+        sig.primary_type = _NuMu
+        sig.target_type = siren.particles.Nucleon
+        sig.secondary_types = [_NuMu, siren.particles.Nucleon]
+        return [sig]
+
+    def GetPossibleSignaturesFromParents(self, primary_type, target_type):
+        return self.GetPossibleSignatures()
+
+    def FinalStateProbability(self, *args):
+        return 1.0
+
+    def DensityVariables(self):
+        return []
+
+    def equal(self, other):
+        return isinstance(other, _PySecondaryCrossSection)
+
+
+def test_save_secondary_trampoline_raises_not_serializable(tmp_path):
+    """save() refuses a Python-subclassed SECONDARY interaction (not just primary).
+
+    A bare detector suffices: the guard reads the Python-side secondary
+    interaction dict before the engine's own archiving is reached. A
+    stopping_condition is supplied so _build() succeeds on its own terms;
+    without one, secondaries with no expansion control are rejected before
+    save() is ever reached.
+    """
+    dm = detector.DetectorModel()
+    inj = injection.Injector(
+        detector=dm,
+        number_of_events=2,
+        seed=1,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(0.0),
+        secondary_interactions={_NuMu: [_PySecondaryCrossSection()]},
+        secondary_injection_distributions={
+            _NuMu: [distributions.SecondaryPhysicalVertexDistribution()]},
+        stopping_condition=lambda datum, i: True,
+    )
+    inj._build()
+    with pytest.raises(siren.errors.NotSerializableError) as exc:
+        inj.save(str(tmp_path / "inj"))
+    assert any("secondary" in o for o in exc.value.offenders)
+
+
+def test_save_stopping_condition_raises_not_serializable(tmp_path):
+    """save() refuses an injector with a stopping condition (not archived)."""
+    dm = detector.DetectorModel()
+    inj = injection.Injector(
+        detector=dm,
+        number_of_events=2,
+        seed=1,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(0.0),
+        stopping_condition=lambda datum, i: True,
+    )
+    inj._build()
+    with pytest.raises(siren.errors.NotSerializableError) as exc:
+        inj.save(str(tmp_path / "inj"))
+    assert any("stopping condition" in o for o in exc.value.offenders)
+
+
+# ------------------------------------------------------------------ #
+#  Duplicate secondary Vertex particle type                           #
+# ------------------------------------------------------------------ #
+
+def test_duplicate_secondary_vertex_type_raises():
+    """Two secondary vertices resolving to the same particle type is loud.
+
+    Both would otherwise silently overwrite each other's interactions and
+    distributions in the by-type maps.
+    """
+    from siren.vertex import Vertex
+
+    pxs = interactions.DummyCrossSection()
+    psig = pxs.GetPossibleSignatures()[0]
+    primary = Vertex(psig.primary_type, pxs,
+                     distributions=_distributions(0.0))
+
+    def _sec(label):
+        xs = interactions.DummyCrossSection()
+        sig = xs.GetPossibleSignatures()[0]
+        return Vertex(
+            sig.primary_type, xs,
+            distributions=[distributions.SecondaryPhysicalVertexDistribution()],
+            label=label)
+
+    va, vb = _sec("a"), _sec("b")
+    # Both resolve to DummyCrossSection's signature primary type.
+    assert va._resolved_particle == vb._resolved_particle
+
+    inj = injection.Injector(
+        detector=detector.DetectorModel(),
+        primary=primary,
+        secondaries=(va, vb),
+        events=2,
+        seed=1,
+    )
+    with pytest.raises(siren.errors.ConfigurationError, match="same particle type"):
+        inj._build()
+
+
+# ------------------------------------------------------------------ #
+#  Secondaries declared with no expansion wiring                      #
+# ------------------------------------------------------------------ #
+
+def test_secondaries_without_expand_raises_at_build():
+    """A spec-form chain that registers a secondary but declares no expand
+    rule anywhere is rejected at build.
+
+    Without an expand declaration (and no legacy stopping condition) the
+    engine's default stopping condition prunes every secondary, silently
+    collapsing the chain to primary-only trees. The expansion-wiring
+    validation runs whenever a chain carries secondaries, so the
+    misconfiguration raises a typed ConfigurationError.
+    """
+    from siren.vertex import Vertex
+
+    pxs = interactions.DummyCrossSection()
+    psig = pxs.GetPossibleSignatures()[0]
+    primary = Vertex(psig.primary_type, pxs,
+                     distributions=_distributions(0.0))
+    # A self-scatter secondary of the same type as the primary/root, so it is
+    # reachable-as-root and the only wiring fault is the absent expand rule
+    # (case (c)); no expand is declared anywhere and no stopping condition is
+    # supplied.
+    secondary = Vertex(
+        psig.primary_type, interactions.DummyCrossSection(),
+        distributions=[distributions.SecondaryPhysicalVertexDistribution()])
+
+    inj = injection.Injector(
+        detector=detector.DetectorModel(),
+        primary=primary,
+        secondaries=(secondary,),
+        events=2,
+        seed=1,
+    )
+    with pytest.raises(siren.errors.ConfigurationError, match="expand"):
+        inj._build()
+
+
+def test_legacy_secondaries_without_stopping_condition_raises_at_build():
+    """A legacy-dict chain with secondaries but no stopping_condition is
+    rejected at build.
+
+    The legacy secondary_interactions/secondary_injection_distributions dict
+    form has no Vertex objects for validate_expansion_wiring to check, so this
+    independent safety net is the only thing that catches it: without a
+    stopping_condition, the engine's default stopping condition prunes every
+    secondary, silently collapsing the chain to primary-only trees.
+    """
+    inj = injection.Injector(
+        detector=detector.DetectorModel(),
+        number_of_events=2,
+        seed=1,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(0.0),
+        secondary_interactions={_NuMu: [interactions.DummyCrossSection()]},
+        secondary_injection_distributions={
+            _NuMu: [distributions.SecondaryPhysicalVertexDistribution()]},
+    )
+    with pytest.raises(siren.errors.ConfigurationError, match="stopping"):
+        inj._build()
+
+
+# ------------------------------------------------------------------ #
+#  Phase-space probe propagates typed SIREN errors                    #
+# ------------------------------------------------------------------ #
+
+def _process_with_phase_space():
+    xs = interactions.DummyCrossSection()
+    sig = xs.GetPossibleSignatures()[0]
+    ic = interactions.InteractionCollection(sig.primary_type, [xs])
+    proc = injection.PrimaryInjectionProcess(sig.primary_type, ic)
+    mc = injection.MultiChannelPhaseSpace()
+    mc.channels = [injection.Isotropic2BodyChannel(0)]
+    mc.weights = [1.0]
+    proc.SetPhaseSpace(sig, mc)
+    return proc
+
+
+class _RaisingValidation:
+    """Stub whose probe_channel_densities raises a chosen exception."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def probe_channel_densities(self, mcps, sig, detector_model, rng):
+        raise self._exc
+
+
+def test_probe_reraises_typed_configuration_error():
+    """A ConfigurationError from the probe propagates (it is a real fault)."""
+    inj = injection.Injector(
+        detector=detector.DetectorModel(),
+        number_of_events=1,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(0.0),
+    )
+    proc = _process_with_phase_space()
+    stub = _RaisingValidation(
+        siren.errors.ConfigurationError("bad model configuration"))
+    rng = utilities.SIREN_random(1)
+    with pytest.raises(siren.errors.ConfigurationError, match="bad model"):
+        inj._probe_phase_spaces(stub, proc, [], rng)
+
+
+def test_probe_swallows_plain_probe_inapplicability():
+    """A bare ValueError/RuntimeError means the probe could not run: swallowed."""
+    inj = injection.Injector(
+        detector=detector.DetectorModel(),
+        number_of_events=1,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(0.0),
+    )
+    proc = _process_with_phase_space()
+    rng = utilities.SIREN_random(1)
+    # A plain ValueError (synthetic template unsolvable) is skipped, not raised.
+    inj._probe_phase_spaces(
+        _RaisingValidation(ValueError("unsolvable template")), proc, [], rng)
+    # A plain RuntimeError that is not a typed SIREN error is likewise skipped.
+    inj._probe_phase_spaces(
+        _RaisingValidation(RuntimeError("engine hiccup")), proc, [], rng)
+
+
+# ------------------------------------------------------------------ #
+#  Pickle round-trip: usable engine, RNG install, guard, stopping cond #
+# ------------------------------------------------------------------ #
+
+def test_pickle_roundtrip_installs_rng_data_free():
+    """generate() after a pickle round-trip must not dereference a null RNG.
+
+    Data-free: every attempt of a bare-detector, zero-distance injector still
+    draws its primary variables from the RNG before missing its target, so a
+    missing RNG install would crash here. It returns zero events, not a crash.
+    """
+    inj = _forced_failure_injector(events=3, seed=11, max_attempts=20)
+    restored = pickle.loads(pickle.dumps(inj))
+    trees = restored.generate(3, on_shortfall="ignore")
+    assert trees == []
+
+
+def test_pickle_roundtrip_plain_injector_generates():
+    """A plain injector round-trips to a usable engine: the restored injector
+    installs a fresh RNG (re-seeded from the stored seed) and generate()
+    produces events instead of segfaulting on a null RNG."""
+    inj = _working_injector(events=5, seed=11)
+    restored = pickle.loads(pickle.dumps(inj))
+    trees = restored.generate(2, on_shortfall="raise")
+    assert len(trees) == 2
+    assert all(len(t.tree) > 0 for t in trees)
+
+
+def test_pickle_roundtrip_preserves_stopping_condition_on_engine():
+    """A chain's stopping condition survives the round-trip and re-attaches to
+    the engine, so secondaries are expanded (some tree has depth >= 1). Without
+    the re-attach the engine default prunes every secondary and all trees
+    collapse to a single vertex."""
+    reference = _chain_injector(seed=7)
+    ref_trees = reference.generate(20, on_shortfall="ignore")
+    if not any(len(t.tree) >= 2 for t in ref_trees):
+        pytest.skip("chain fixture produced no multi-vertex events to pin")
+
+    inj = _chain_injector(seed=7)
+    restored = pickle.loads(pickle.dumps(inj))
+    trees = restored.generate(20, on_shortfall="ignore")
+    assert any(len(t.tree) >= 2 for t in trees)
+
+
+def test_pickle_roundtrips_phase_space_map():
+    """Pickle preserves the facade and engine views of a phase-space map."""
+    inj = _forced_failure_injector(events=2, seed=1)
+    inj._build()
+    xs = interactions.DummyCrossSection()
+    sig = xs.GetPossibleSignatures()[0]
+    mc = injection.MultiChannelPhaseSpace()
+    mc.channels = [injection.Isotropic2BodyChannel(0)]
+    mc.weights = [1.0]
+    inj.primary_phase_spaces = {sig: mc}
+
+    restored = pickle.loads(pickle.dumps(inj))
+    restored_mc = restored.primary_phase_spaces[sig]
+    engine_mc = restored.engine.GetPrimaryProcess().GetPhaseSpaceMap()[sig]
+    assert list(restored_mc.weights) == [1.0]
+    assert restored_mc is engine_mc
+
+
+def test_pickle_allows_stopping_condition():
+    """A stopping condition is not a pickle offender (the state tuple carries
+    it), so pickling an injector whose only save()-offender is a stopping
+    condition succeeds and the condition round-trips."""
+    inj = injection.Injector(
+        detector=detector.DetectorModel(),
+        number_of_events=2,
+        seed=1,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(0.0),
+        stopping_condition=_depth_ge_1,
+    )
+    inj._build()
+    blob = pickle.dumps(inj)   # must not raise
+    restored = pickle.loads(blob)
+    assert restored.stopping_condition is _depth_ge_1
+
+
+# ------------------------------------------------------------------ #
+#  seed setter on a built engine                                      #
+# ------------------------------------------------------------------ #
+
+def test_seed_setter_after_build_reseeds_and_generates():
+    """Setting .seed on a built injector must reseed generation, not raise.
+
+    The raw engine exposes only SetRandom, so the setter installs a fresh
+    engine seeded from the new value (streams restart, not resume). Data-free:
+    the forced-failure fixture draws from the RNG on every attempt, so a
+    broken setter or a missing engine would surface here."""
+    inj = _forced_failure_injector(events=2, seed=1, max_attempts=20)
+    inj._build()
+    inj.seed = 42
+    assert inj.seed == 42
+    trees = inj.generate(2, on_shortfall="ignore")
+    assert trees == []
+    assert inj.injection_attempts > 0

--- a/tests/python/test_legacy_shims.py
+++ b/tests/python/test_legacy_shims.py
@@ -1,0 +1,147 @@
+"""Legacy keyword and Vertex-spec entry points compile to one engine config.
+
+The two authoring surfaces are a translation shim over a single build path, so
+at a fixed seed they must produce identical event streams. These tests
+parametrize a shared scenario over both surfaces and assert stream identity of
+the generated trees and their weights.
+"""
+
+import os
+
+import pytest
+
+import siren
+from siren import dataclasses as dc
+from siren import injection
+from siren import interactions
+from siren import distributions
+from siren import detector
+from siren import math as smath
+from siren import utilities
+from siren import _util
+
+_NuMu = dc.Particle.ParticleType.NuMu
+
+
+def _skip_unless_ccm_data():
+    try:
+        det_dir = _util.get_detector_model_path("CCM")
+    except ValueError as e:
+        pytest.skip("CCM detector model path unavailable: {}".format(e))
+    for name in ("materials.dat", "densities.dat"):
+        if not os.path.exists(os.path.join(det_dir, name)):
+            pytest.skip("CCM detector data missing: " + name)
+
+
+def _load_ccm_detector():
+    dm = detector.DetectorModel()
+    det_dir = _util.get_detector_model_path("CCM")
+    dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+    dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    return dm
+
+
+def _distributions():
+    return [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(
+            smath.Vector3D(0, 0, 0), 25.0),
+    ]
+
+
+SEED = 20240601
+N = 25
+
+
+def _build_legacy(dm):
+    """The scenario spelled with legacy keyword arguments."""
+    return injection.Injector(
+        number_of_events=N,
+        detector_model=dm,
+        seed=SEED,
+        primary_type=_NuMu,
+        primary_interactions=[interactions.DummyCrossSection()],
+        primary_injection_distributions=_distributions(),
+    )
+
+
+def _build_spec(dm):
+    """The same scenario spelled with a Vertex spec."""
+    v = siren.Vertex(
+        _NuMu,
+        interactions.DummyCrossSection(),
+        distributions=_distributions(),
+    )
+    return injection.Injector(detector=dm, primary=v, events=N, seed=SEED)
+
+
+def _stream(injector):
+    """Realized (energy, vertex, depth) stream from a fixed-seed run."""
+    trees = injector.generate(N, on_shortfall="raise")
+    rows = []
+    for t in trees:
+        root = t.tree[0].record
+        rows.append((
+            tuple(root.primary_momentum),
+            tuple(root.interaction_vertex),
+        ))
+    return rows
+
+
+@pytest.fixture
+def ccm_detector():
+    _skip_unless_ccm_data()
+    return _load_ccm_detector()
+
+
+def test_legacy_and_spec_produce_identical_streams(ccm_detector):
+    """Legacy kwargs and a Vertex spec yield byte-identical event streams."""
+    legacy = _build_legacy(ccm_detector)
+    spec = _build_spec(ccm_detector)
+
+    legacy_stream = _stream(legacy)
+    spec_stream = _stream(spec)
+
+    assert len(legacy_stream) == len(spec_stream) == N
+    assert legacy_stream == spec_stream
+
+
+def test_legacy_and_spec_produce_identical_weights(ccm_detector):
+    """The two surfaces weight their (identical) events identically."""
+    legacy = _build_legacy(ccm_detector)
+    spec = _build_spec(ccm_detector)
+
+    legacy_trees = legacy.generate(N, on_shortfall="raise")
+    spec_trees = spec.generate(N, on_shortfall="raise")
+
+    phys = [
+        distributions.PrimaryMass(0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+    ]
+
+    def _weighter_for(inj):
+        w = injection.Weighter()
+        w.injectors = [inj]
+        w.detector_model = ccm_detector
+        w.primary_type = _NuMu
+        w.primary_interactions = inj.primary_interactions
+        w.primary_physical_distributions = list(phys)
+        return w
+
+    lw = _weighter_for(legacy).weight_all(legacy_trees)
+    sw = _weighter_for(spec).weight_all(spec_trees)
+
+    assert list(lw) == list(sw)
+
+
+@pytest.mark.parametrize("build", [_build_legacy, _build_spec],
+                         ids=["legacy", "spec"])
+def test_both_surfaces_generate_requested_count(build, ccm_detector):
+    """Each surface generates exactly the requested number of events."""
+    inj = build(ccm_detector)
+    trees = inj.generate(N, on_shortfall="raise")
+    assert len(trees) == N

--- a/tests/python/test_top_level_namespace.py
+++ b/tests/python/test_top_level_namespace.py
@@ -21,5 +21,6 @@ def test_top_level_count_reasonable():
     )
     out = subprocess.check_output([sys.executable, "-c", code], text=True)
     count = int(out.strip())
-    # Should be around 25, definitely under 30.
-    assert count < 30, f"Too many top-level names: {count}"
+    # The spec vocabulary (Vertex, Directed, channels, expand, errors,
+    # generate, Propagated, Fixed) is part of the intended public surface.
+    assert count < 45, f"Too many top-level names: {count}"

--- a/tests/python/test_weighter_explain.py
+++ b/tests/python/test_weighter_explain.py
@@ -1,0 +1,192 @@
+"""Weighter.explain() over the engine breakdown, weight_all as ndarray, and
+the removal of private-injector reach-throughs.
+
+Data-free where possible; the assembled-chain tests skip cleanly when the CCM
+detector data files are absent.
+"""
+
+import math
+import os
+import warnings
+
+import numpy as np
+import pytest
+
+import siren
+from siren import dataclasses as dc
+from siren import injection
+from siren import interactions
+from siren import distributions
+from siren import detector
+from siren import math as smath
+from siren import utilities
+from siren import _util
+
+_NuMu = dc.Particle.ParticleType.NuMu
+
+
+def _skip_unless_ccm_data():
+    try:
+        det_dir = _util.get_detector_model_path("CCM")
+    except ValueError as e:
+        pytest.skip("CCM detector model path unavailable: {}".format(e))
+    for name in ("materials.dat", "densities.dat"):
+        if not os.path.exists(os.path.join(det_dir, name)):
+            pytest.skip("CCM detector data missing: " + name)
+
+
+def _load_ccm_detector():
+    dm = detector.DetectorModel()
+    det_dir = _util.get_detector_model_path("CCM")
+    dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+    dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    return dm
+
+
+def _build_pair(dm, seed=4242):
+    xs = interactions.DummyCrossSection()
+    inj_dists = [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+    inj = injection.Injector(
+        number_of_events=50, detector_model=dm, seed=seed,
+        primary_type=_NuMu, primary_interactions=[xs],
+        primary_injection_distributions=inj_dists)
+
+    weighter = injection.Weighter()
+    weighter.injectors = [inj]
+    weighter.detector_model = dm
+    weighter.primary_type = _NuMu
+    weighter.primary_interactions = [xs]
+    weighter.primary_physical_distributions = [
+        distributions.PrimaryMass(0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+    ]
+    return inj, weighter
+
+
+# ------------------------------------------------------------------ #
+#  explain(): breakdown reconstructs the weight                        #
+# ------------------------------------------------------------------ #
+
+def test_explain_total_matches_scalar_weight():
+    """explain(tree).total equals the scalar event weight to 1e-12."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj, weighter = _build_pair(dm)
+
+    trees = inj.generate(5, on_shortfall="ignore")
+    if not trees:
+        pytest.skip("no events generated for this data-free chain")
+    for tree in trees:
+        breakdown = weighter.explain(tree)
+        scalar = weighter(tree)
+        if math.isfinite(scalar) and math.isfinite(breakdown.total):
+            assert abs(breakdown.total - scalar) <= 1e-12 * max(1.0, abs(scalar))
+        else:
+            assert math.isnan(breakdown.total) == math.isnan(scalar)
+
+
+def test_explain_returns_weight_breakdown_with_vertices():
+    """explain(tree) yields a report.WeightBreakdown with per-vertex lines."""
+    from siren.report import WeightBreakdown
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj, weighter = _build_pair(dm)
+    trees = inj.generate(3, on_shortfall="ignore")
+    if not trees:
+        pytest.skip("no events generated")
+    bd = weighter.explain(trees[0])
+    assert isinstance(bd, WeightBreakdown)
+    assert len(bd.vertices) >= 1
+    assert "WeightBreakdown" in str(bd)
+
+
+# ------------------------------------------------------------------ #
+#  breakdown() is a deprecated alias                                  #
+# ------------------------------------------------------------------ #
+
+def test_breakdown_is_deprecated_alias():
+    """breakdown(tree) emits a DeprecationWarning and matches explain()."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj, weighter = _build_pair(dm)
+    trees = inj.generate(2, on_shortfall="ignore")
+    if not trees:
+        pytest.skip("no events generated")
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        bd = weighter.breakdown(trees[0])
+    assert any(issubclass(x.category, DeprecationWarning) for x in w)
+    assert bd.total == weighter.explain(trees[0]).total
+
+
+# ------------------------------------------------------------------ #
+#  weight_all returns a numpy array                                   #
+# ------------------------------------------------------------------ #
+
+def test_weight_all_returns_ndarray():
+    """weight_all(trees) returns a numpy.ndarray matching per-event weights."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    inj, weighter = _build_pair(dm)
+    trees = inj.generate(5, on_shortfall="ignore")
+    if not trees:
+        pytest.skip("no events generated")
+    batch = weighter.weight_all(trees)
+    assert isinstance(batch, np.ndarray)
+    individual = np.array([weighter(t) for t in trees])
+    assert np.array_equal(batch, individual, equal_nan=True)
+
+
+# ------------------------------------------------------------------ #
+#  public engine property is the only path to the raw injector       #
+# ------------------------------------------------------------------ #
+
+def test_no_private_injector_reach_through_in_source():
+    """Weighter.py reaches the raw injector via the public engine property."""
+    src_path = os.path.join(os.path.dirname(_util.__file__), "Weighter.py")
+    with open(src_path) as f:
+        source = f.read()
+    assert "_Injector__injector" not in source
+
+
+# ------------------------------------------------------------------ #
+#  spec-form constructor accepts injectors                            #
+# ------------------------------------------------------------------ #
+
+def test_spec_form_ctor_accepts_injectors():
+    """Weighter(injector, primary_physical=[...]) builds a working weighter."""
+    _skip_unless_ccm_data()
+    dm = _load_ccm_detector()
+    xs = interactions.DummyCrossSection()
+    inj_dists = [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, 0.5, 5.0),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+    inj = injection.Injector(
+        number_of_events=10, detector_model=dm, seed=7,
+        primary_type=_NuMu, primary_interactions=[xs],
+        primary_injection_distributions=inj_dists)
+
+    weighter = injection.Weighter(
+        inj,
+        primary_physical=[
+            distributions.PrimaryMass(0),
+            distributions.PrimaryNeutrinoHelicityDistribution(),
+            distributions.IsotropicDirection(),
+        ])
+    trees = inj.generate(3, on_shortfall="ignore")
+    if not trees:
+        pytest.skip("no events generated")
+    weights = weighter.weight_all(trees)
+    assert isinstance(weights, np.ndarray)
+    assert len(weights) == len(trees)

--- a/tests/python/test_weighter_inheritance.py
+++ b/tests/python/test_weighter_inheritance.py
@@ -1,0 +1,146 @@
+"""Vertex physical declarations reach weighting without changing generation."""
+
+import gc
+import pickle
+import weakref
+
+import numpy as np
+import pytest
+
+import siren
+from siren import distributions as d, injection, interactions
+from siren.errors import NotSerializableError
+from test_injector_api import _distributions, _load_ccm_detector, _depth_ge_1
+from test_vertex_spec import _KeepAliveCrossSection
+
+PT = siren.dataclasses.ParticleType
+
+
+def _injector(*, chain=True):
+    primary = siren.Vertex(
+        PT.NuMu, interactions.DummyCrossSection(),
+        distributions=_distributions(25.0),
+        physical=[d.NormalizationConstant(0.2)],
+        physical_interactions=interactions.DummyCrossSection())
+    secondary = siren.Vertex(
+        PT.NuMu, interactions.DummyCrossSection(),
+        position=d.SecondaryPhysicalVertexDistribution(),
+        physical=[d.NormalizationConstant(0.7)],
+        physical_interactions=interactions.DummyCrossSection())
+    return injection.Injector(
+        detector=_load_ccm_detector(), primary=primary,
+        secondaries=[secondary] if chain else [],
+        stopping_condition=_depth_ge_1 if chain else None,
+        events=5, max_attempts=5000, seed=71)
+
+
+def test_inherited_primary_and_secondary_weights_match_explicit_configuration():
+    inj = _injector()
+    p, s = inj.primary, inj.secondaries[0]
+    inherited = injection.Weighter(inj)
+    explicit = injection.Weighter(
+        inj, primary_physical=p.physical,
+        secondary_physical={PT.NuMu: s.physical},
+        overrides={"primary_interactions": p.physical_interactions,
+                   "secondary_interactions": {PT.NuMu: s.physical_interactions}})
+    conditional = injection.Weighter(inj, primary_physical=[], secondary_physical={})
+    trees = inj.generate(5, on_shortfall="raise", on_failure="raise")
+    assert all(len(tree.tree) == 2 for tree in trees)
+    expected = explicit.weight_all(trees)
+    assert np.all(expected > 0)
+    np.testing.assert_array_equal(inherited.weight_all(trees), expected)
+    np.testing.assert_allclose(expected / conditional.weight_all(trees), 0.2 * 0.7,
+                               rtol=1e-12, atol=0)
+    for tree, weight in zip(trees, expected):
+        assert inherited.explain(tree).total == pytest.approx(weight, rel=1e-12, abs=0)
+    assert inherited.engine.GetPrimaryPhysicalProcess().interactions.GetCrossSections()[0] is p.physical_interactions[0]
+    assert inherited.engine.GetSecondaryPhysicalProcesses()[0].interactions.GetCrossSections()[0] is s.physical_interactions[0]
+    assert inj.engine.GetPrimaryProcess().interactions.GetCrossSections()[0] is p.interactions[0]
+    assert inj.engine.GetSecondaryProcessMap()[PT.NuMu].interactions.GetCrossSections()[0] is s.interactions[0]
+
+
+def test_explicit_overrides_replace_inheritance_including_empty_collections():
+    inj = _injector()
+    model = interactions.DummyCrossSection()
+    w = injection.Weighter(inj, primary_physical=[], secondary_physical={},
+                           overrides={"primary_interactions": [model],
+                                      "secondary_interactions": {}})
+    assert w.primary_physical_distributions == []
+    assert w.secondary_physical_distributions == {}
+    assert w.primary_interactions[0] is model
+    assert w.secondary_interactions == {}
+
+
+@pytest.mark.parametrize("raw", [False, True])
+def test_legacy_and_raw_injectors_keep_sampling_model_defaults(raw):
+    spec = _injector(chain=False)
+    inj = injection.Injector(
+        detector=spec.detector_model, events=5,
+        primary_type=PT.NuMu, primary_interactions=spec.primary.interactions,
+        primary_injection_distributions=spec.primary.distributions)
+    w = injection.Weighter(inj.engine if raw else inj)
+    assert w.primary_interactions[0] is spec.primary.interactions[0]
+    assert w.primary_physical_distributions == []
+    assert w.secondary_physical_distributions == {}
+
+
+def test_none_inherits_sampling_models_and_first_injector_defines_pooled_target():
+    first, second = _injector(), _injector()
+    first.primary.physical_interactions = None
+    first.secondaries[0].physical_interactions = None
+    w = injection.Weighter(first, second)
+    assert w.primary_interactions[0] is first.primary.interactions[0]
+    assert w.secondary_interactions[PT.NuMu][0] is first.secondaries[0].interactions[0]
+    assert w.primary_physical_distributions[0] is first.primary.physical[0]
+
+
+def test_weighter_owns_copies_of_inherited_lists_and_python_models():
+    inj = _injector()
+    model = _KeepAliveCrossSection()
+    ref = weakref.ref(model)
+    inj.primary.physical_interactions = [model]
+    inj.secondaries[0].physical_interactions = [model]
+    w = injection.Weighter(inj)
+    inj.primary.physical_interactions.clear()
+    inj.primary.physical.clear()
+    inj.secondaries[0].physical_interactions.clear()
+    inj.secondaries[0].physical.clear()
+    del model
+    gc.collect()
+    assert w.primary_interactions[0] is ref()
+    assert w.secondary_interactions[PT.NuMu][0] is ref()
+    assert ref().TotalCrossSection(None) == 1.0
+    assert len(w.primary_physical_distributions) == 1
+    assert len(w.secondary_physical_distributions[PT.NuMu]) == 1
+    with pytest.raises(NotSerializableError, match="Python subclass"):
+        w._guard_serializable(siren.errors)
+
+
+@pytest.mark.parametrize("field", ["physical", "physical_interactions"])
+@pytest.mark.parametrize("secondary", [False, True])
+@pytest.mark.parametrize("archive", ["save", "pickle"])
+def test_injector_refuses_to_drop_physical_declarations(tmp_path, field, secondary, archive):
+    inj = _injector(chain=secondary)
+    for vertex in [inj.primary, *inj.secondaries]:
+        vertex.physical = []
+        vertex.physical_interactions = None
+    vertex = inj.secondaries[0] if secondary else inj.primary
+    setattr(vertex, field, [d.NormalizationConstant(0.3)] if field == "physical"
+            else [interactions.DummyCrossSection()])
+    with pytest.raises(NotSerializableError, match="declares physical"):
+        if archive == "save":
+            inj.save(str(tmp_path / "injector"))
+        else:
+            pickle.dumps(inj)
+
+
+def test_weighter_archive_preserves_inherited_physical_processes(tmp_path):
+    inj = _injector(chain=False)
+    trees = inj.generate(3, on_shortfall="raise", on_failure="raise")
+    w = injection.Weighter(inj)
+    expected = w.weight_all(trees)
+    filename = str(tmp_path / "weighter")
+    w.save(filename)
+    restored = injection.Weighter()
+    restored.load(filename)
+    np.testing.assert_allclose(restored.weight_all(trees), expected, rtol=1e-12, atol=0)


### PR DESCRIPTION
This PR reworks the python Injector and Weighter around a single validation
choke point, an events-counting generate() with an on_shortfall policy, and a
Weighter.explain(tree) that renders the engine's weight breakdown. The legacy
keyword form and the Vertex-spec form compile to the same engine build path,
so a misconfiguration in either fails loud and silently dropped state is
refused, and both forms produce an identical event stream at a fixed seed.
The choke point also validates expansion wiring whenever a chain carries
secondary vertices and no legacy stopping condition governs it, so
secondaries with no expand rule raise a typed ConfigurationError instead of
the engine default silently pruning every tree to the primary.

The persistence surface is born with its full contract: save() refuses
configurations the archive cannot round-trip (phase-space maps,
Python-subclass models, stopping conditions), load() constructs the engine
through the archive-loading constructor and starts a fresh unseeded stream,
pickle preserves a stopping condition (re-attached to the engine on
unpickle) and re-seeds from the stored seed, the seed setter installs a
freshly seeded engine through SetRandom, and RNG streams restart rather than
resume across round-trips. Weighter.save mirrors the injector guard.
export_tuning/apply_tuning document the ordering contract that events
generated before a re-tune must not be weighted afterwards.

ComputeVertexFactors populates per-vertex channel densities and cancelled
distributions on the diagnostics path, top-level generate()/report() modules
wire an injector and weighter into a rendered Results and failure ledger, and
a Mixture's composition scale, expand-graph validation, and PDG-to-name
rendering round out the report and channel-algebra surfaces. The report
module's particle naming reads the dataclasses enum directly from birth; the
follow-up commit that previously carried that fix is folded in.

At this PR's boundary: the build is green; pytest 725 passed, 25 skipped, 16 warnings.

Supersedes #164 (`pr/spec-vocabulary`); pre-rewrite history is preserved at
tag `archive/v1/spec-vocabulary`.

Note: this branch's history was consolidated a second time after review
began; line-anchored review comments (from either round) may reference
superseded line numbers.
