### PR TITLE
Add user docs and naming cleanups

### DIFF
--- a/docs/errors.md
+++ b/docs/errors.md
@@ -1,0 +1,95 @@
+# Error reference
+
+SIREN error messages that originate from the C++ engine end with a tag like
+`[siren-docs: errors#configuration]`. Find the token after `errors#` in the
+message, then read the matching section below.
+
+## errors#configuration
+
+**What raises it.** Injector/Weighter process configuration mismatches,
+raised as `ConfigurationError`:
+
+- the `Weighter`'s primary physical process does not match the `Injector`'s
+  primary process ("does not match the injector primary process");
+- a secondary physical process does not match its injector's secondary
+  process, or has no matching injector secondary process at all
+  ("has no matching injector secondary process");
+- the injector's secondary processes and the weighter's secondary processes
+  are not in one-to-one correspondence ("no one-to-one mapping between
+  injection ... and physical ... secondary processes");
+- a `MultiChannelPhaseSpace` has a `weights` list whose size does not match
+  its `channels` list, has a weight that is not finite and non-negative, has
+  weights that do not sum to 1, or has no channels at all
+  ("call Normalize() or use the validating constructor" /
+  "MultiChannelPhaseSpace has no channels").
+
+**The fix.** Ensure the physical processes passed to the `Weighter` mirror
+the `Injector`'s processes exactly (same primary type, same set of secondary
+types, matching collections). For a hand-built channel mixture, call
+`MultiChannelPhaseSpace.Normalize()` (or use the validating constructor)
+before using it -- do not assign `weights` and `channels` separately without
+normalizing. See `docs/quickstart.md`'s closure check and this repository's
+config/closure gauges for a way to catch this before a full run.
+
+## errors#measure-compat
+
+**What raises it.** A `MeasureCompatibilityError` when phase-space densities
+cannot be compared pointwise in one convention. Common cases are:
+
+- channel topologies disagree ("Topology mismatch: channel 0 ... is
+  `<Topology>` but channel `i` ... is `<Topology>`");
+- a channel's `Measure()` cannot be converted to the mixture's common measure
+  within the shared topology ("Measure incompatibility: channel `i` ... uses
+  `<Measure>` which is not convertible to `<Measure>` within `<Topology>`
+  topology");
+- code asks to integrate an explicit azimuth at one sampled point ("cannot
+  marginalize an explicit azimuth pointwise; evaluate the mixture in an
+  explicit-azimuth measure");
+- `PhysicalProcess::SetPhaseSpace` is given a same-topology, same-family
+  mixture measure that the model density cannot reach pointwise ("Phase space
+  registered for a signature is not convertible from that interaction
+  model's final-state convention"); or
+- multiple models for one signature declare conventions with no common
+  pointwise density measure.
+
+The scattering measures distinguish an azimuth-integrated marginal from its
+explicit-azimuth completion: for example `MandelstamQ2` is `dQ^2`, while
+`MandelstamQ2Phi` is `dQ^2 dphi`. Conversion is directional. A marginal that
+declares the omitted azimuth uniform can be lifted to its explicit completion
+by multiplying the density by `1/(2*pi)`. The reverse operation is an
+integral, not a pointwise Jacobian, and therefore throws.
+
+Mixtures elect a common measure that every channel can reach in that
+direction. Consequently, one explicit-azimuth channel forces an explicit
+common measure and integrated channels lift into it. Other convertible
+coordinate changes auto-convert silently.
+
+**The fix.** Give every channel in a mixture the same `Topology()` and a
+`Measure()` that can convert into the elected common measure. Check
+`PhaseSpaceDensityConvertible(topology, from_measure, to_measure)` in that
+direction; do not assume convertibility is symmetric. For a physical adapter
+whose model metadata cannot express the density precisely, use the
+`(model, signature, convention)` constructor to declare it explicitly. See
+`docs/units_conventions.md` for the rest-frame-vs-lab-frame distinction
+between `SolidAngleRest` and `SolidAngleLab`, another common source of an
+inconvertible pairing.
+
+## errors#weight-calc
+
+**What raises it.** A `WeightCalculationError` when `Weighter::EventWeight`
+cannot form a usable weight for an event: the accumulated
+`generation_probability` is `<= 0` or non-finite, or the accumulated
+`physical_probability` is non-finite ("unusable probabilities for injector
+... generation_probability=..., physical_probability=...").
+
+An event with `physical_probability == 0` (out-of-physical-support kinematics)
+is NOT an error: it weights to exactly `0.0` by design, since that drives the
+weight reciprocal to `+inf` correctly. Only a non-finite or non-positive
+generation probability, or a non-finite physical probability, raises.
+
+**The fix.** If you see this for an event that should be in-support, check
+the offending injector's distributions and the event's kinematics: a
+distribution returning a non-finite or negative density anywhere in its
+support will surface here the first time that region is sampled. Run
+`siren.check_closure` (`docs/quickstart.md`) on the model responsible for the
+vertex to find which distribution's density disagrees with its sampler.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,119 @@
+# Quickstart
+
+SIREN is a two-phase Monte Carlo framework: injection draws biased samples of
+rare event topologies, and weighting computes the importance weight that maps
+each sample back to the physical distribution it represents. This page is the
+smallest end-to-end taste of both phases: define a model, verify its sampler
+and its density agree, then see the shape of a full simulation run.
+
+## Define a model
+
+A physics model is a small Python class: declare the particles and the
+phase-space measure, then implement the width (or cross section) as two
+hooks. Here is a two-body decay with an isotropic angular distribution in the
+parent rest frame:
+
+```python
+import math, siren
+
+class IsoDecay(siren.DecayModel):
+    parent = "N4"
+    daughters = ("NuLight", "Gamma")
+    measure = siren.Measure.SolidAngleRest()
+
+    def total_width(self):
+        return 1.0
+
+    def differential_width(self, record):
+        return 1.0 / (4.0 * math.pi)
+
+    def density_variables(self):
+        return "cost"
+```
+
+`siren.DecayModel` derives the interaction signature, the topology, and
+`FinalStateProbability` (differential over total) from these hooks. Because
+the declared measure (`SolidAngleRest`) has a self-contained default sampler,
+you get a working `SampleFinalState` for free -- you only had to describe the
+physics.
+
+## Check it closes
+
+Every weight in SIREN is `PhysicalProbability / GenerationProbability`. That
+ratio is only meaningful if the sampler's distribution and the model's own
+density (`FinalStateProbability`) describe the same thing. `check_closure`
+quantifies whether they do:
+
+```python
+report = siren.check_closure(IsoDecay())
+print(report)
+print(report.ok)
+```
+
+Actual output from this exact model:
+
+```
+Closure report: PASS
+  normalization (absolute) E[f/g_ref] = 1.0000 +/- 0.0000 (expect 1.0)
+  flatness (shape only) = 1.0000 +/- 0.0224 (self-normalized bin ratios; blind to a uniform scale error)
+  moment z-scores:
+    costheta_secondary0_rest: z=-1.70
+  worst region: costheta_secondary0_rest in [-0.40, -0.30): ratio 1.19 (z=1.7)
+True
+```
+
+Closure means the biased sampler and the physical density agree, so weights
+computed against this model are unbiased -- no hidden shape or normalization
+error that statistics alone would never reveal.
+
+## Run a simulation
+
+The `Simulation` facade wires a detector, a primary particle, an interaction
+model, and injection/physical distributions into one object that runs both
+phases:
+
+```python
+import siren
+
+sim = siren.Simulation(
+    events=100_000,
+    detector="IceCube",
+    primary="NuMu",
+    interactions="CSMSDISSplines",
+    targets="Nucleon",
+    process="CC",
+    energy=siren.dist.PowerLaw(2, 1e3, 1e6),
+    direction=siren.dist.IsotropicDirection(),
+    position=siren.dist.ColumnDepth(
+        600, 600.0, siren.distributions.LeptonDepthFunction()),
+)
+results = sim.run()
+len(results)                       # number of generated events
+for event, weight in results:
+    pass                          # event: InteractionTree, weight: float
+sim.describe()                     # human-readable summary of the pipeline
+```
+
+This snippet needs a detector model and cross-section splines to run (both
+loaded from `resources/`), so it is shown here but not executed on this page.
+See `docs/quickstart.md`'s companion tests (`tests/python/test_simulation_api.py`)
+for a runnable version against the `IceCube` detector and `CSMSDISSplines`.
+
+`results` is a `siren.Results`: iterate it for `(event, weight)` pairs, index
+or slice it, and call `results.summary()` for a weight-quality report.
+
+## Which layer do I use?
+
+Use the `Simulation` facade for standard runs. Drop to the Layer-2
+`Injector`/`Weighter` objects (`sim.injector`, `sim.weighter`) only when you
+need to inspect or drive generation directly -- each `run()` call builds its
+own `Injector`/`Weighter` from the `Simulation`'s stored configuration, so
+`sim.injector`/`sim.weighter` only reflect the objects a call to `run()` used
+once that call has returned; accessing them beforehand does not let you
+customize the objects `run()` will build.
+
+## Next steps
+
+- `docs/units_conventions.md` -- units, geometry argument conventions, frames,
+  and the RNG reproducibility contract.
+- `docs/errors.md` -- what each SIREN error message means and how to fix it.

--- a/docs/units_conventions.md
+++ b/docs/units_conventions.md
@@ -1,0 +1,95 @@
+# Units and conventions
+
+## Units
+
+Energies and masses are in GeV, lengths are in meters, and times are in
+nanoseconds (ns). Internally, SIREN fixes `meter = 1` and `second = 1e9`, so a
+time value of `1.0` is 1 ns; this is the convention HepMC3 export also uses
+for vertex/particle times.
+
+## Geometry arguments are FULL widths
+
+`Box` and similar geometry constructors take FULL side lengths, not
+half-widths:
+
+```python
+box = siren.geometry.Box(widths=(x, y, z), center=(cx, cy, cz))
+```
+
+Here `x`, `y`, `z` are the full extents of the box along each axis (a cube
+with `widths=(2.0, 2.0, 2.0)` spans from -1.0 to +1.0 on each side of its
+center). GDML `<box>` `x`/`y`/`z` attributes are also full lengths, not half
+lengths.
+
+This is a known footgun: reading a full-width value as a half-width silently
+doubles a volume's size. Always use `widths=`/`center=` and confirm which
+convention a given geometry constructor documents; do not assume it matches
+GDML's `<box>` (some GDML solids, like `<trd>`/`<trap>`, are natively defined
+in terms of half lengths, and SIREN's GDML parser halves those on read -- see
+the parser's per-solid handling, not this page, for the authoritative list).
+
+The positional form `Box(x, y, z)` would place the box at the ORIGIN,
+silently dropping any intended center, so it is rejected: it unconditionally
+raises `ConfigurationError`, naming the `widths=`/`center=` fix-it in its
+message. Always use the explicit form:
+
+```python
+# Raises ConfigurationError: use widths=/center= instead.
+box = siren.geometry.Box(1.0, 2.0, 3.0)
+
+# Correct: explicit widths and center.
+box = siren.geometry.Box(widths=(1.0, 2.0, 3.0), center=(0.0, 0.0, 5.0))
+```
+
+## Frames and coordinates
+
+Positions stored in `InteractionRecord` are in DETECTOR coordinates (the
+detector model's local frame), not a beamline or geocentric frame. Loaders
+such as `siren.utilities.load_detector` handle the transform from a beamline
+frame (e.g. BNB) into detector-local coordinates when composing geometry.
+
+Phase-space measures name the frame a solid angle is defined in:
+`Measure.SolidAngleRest()` is uniform solid angle in the parent's rest frame;
+`Measure.SolidAngleLab()` is uniform solid angle in the lab frame. These are
+not interchangeable -- a sampler built for one and checked (or weighted)
+against the other will show a systematic angular bias. `check_closure`'s
+frame heuristic flags exactly this: a declared `SolidAngleRest` measure whose
+samples actually look isotropic in the lab frame (or vice versa).
+
+## RNG and reproducibility (two-stream contract)
+
+SIREN maintains two independent RNG streams:
+
+- a GENERATION stream, which drives event sampling (the `Injector`'s seed);
+- a VALIDATION stream, which drives gauges, probes, and diagnostics (for
+  example `check_closure`'s `seed` argument, which defaults to `seed=0` and
+  is entirely separate from any generation seed).
+
+Adding or running a diagnostic only draws from the validation stream, so it
+can never shift a generation-stream result -- running `check_closure` on a
+model, or probing a phase-space mixture, does not perturb any event stream
+produced by an `Injector` with the same seed. Fixing a seed makes a
+generation run reproducible: same seed, same configuration, same SIREN
+version implies an identical event stream.
+
+Serialization does NOT resume an RNG stream mid-sequence. Neither the C++
+archive (`save`/`load`) nor pickle carries the random engine, so a reloaded or
+unpickled injector begins a fresh generation stream. Pickle re-seeds that
+stream from the stored seed, so a fresh injector and an unpickled one produce
+the same stream from the start; `load` starts unseeded. Either way, an injector
+that had already generated some events continues differently after a round-trip
+than it would have run uninterrupted -- the round-trip restarts the stream, it
+does not resume it.
+
+## Environment variables
+
+`SIREN_STRICT=1` is the only supported environment toggle. Setting it
+escalates SIREN's `DeprecationWarning`s (emitted for deprecated aliases like
+`Simulation(n_events=...)`) to hard errors, which is useful for finding
+remaining legacy call sites in a codebase before a deprecated form is
+removed. This is implemented in `siren`'s package `__init__`. Positional
+`Box(x, y, z)` is not a warning case: it raises `ConfigurationError`
+unconditionally.
+
+`SIREN_QUIET` is not a supported toggle: nothing in the library reads it.
+Setting it has no effect; do not rely on it to suppress warnings or errors.

--- a/projects/geometry/private/pybindings/geometry.cxx
+++ b/projects/geometry/private/pybindings/geometry.cxx
@@ -23,6 +23,8 @@
 #include "../../public/SIREN/geometry/Para.h"
 #include "../../public/SIREN/geometry/GeometryMesh.h"
 
+#include "../../../utilities/public/SIREN/utilities/Errors.h"
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
@@ -93,16 +95,12 @@ PYBIND11_MODULE(geometry,m) {
 
     class_<Box, std::shared_ptr<Box>, Geometry>(m, "Box")
         .def(init<>())
-        // Positional Box(x, y, z) places the box at the ORIGIN, which reads as
-        // a size-only constructor and silently drops the intended center. Warn
-        // and keep the origin placement rather than raising, so positional
-        // callers are not broken immediately.
-        .def(init([](double x, double y, double z) {
-            PyErr_WarnEx(PyExc_DeprecationWarning,
+        // Positional Box(x, y, z) reads as size-only and silently drops the
+        // intended center, so it raises with the keyword fix-it.
+        .def(init([](double x, double y, double z) -> std::shared_ptr<Box> {
+            throw siren::utilities::ConfigurationError(
                 "Box(x, y, z) places the box at the ORIGIN; pass "
-                "Box(widths=(x, y, z), center=(cx, cy, cz))",
-                1);
-            return std::make_shared<Box>(x, y, z);
+                "Box(widths=(x, y, z), center=(cx, cy, cz))");
         }))
         .def(init([](std::array<double, 3> widths, std::array<double, 3> center) {
             Placement placement(siren::math::Vector3D(center[0], center[1], center[2]));

--- a/tests/python/test_injector_api.py
+++ b/tests/python/test_injector_api.py
@@ -218,16 +218,13 @@ def test_typo_secondary_key_raises():
 
 
 # ------------------------------------------------------------------ #
-#  positional Box warns but still constructs                          #
+#  positional Box raises                                              #
 # ------------------------------------------------------------------ #
 
-def test_positional_box_warns_and_constructs():
-    """Box(x, y, z) emits a DeprecationWarning and still builds a box."""
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        box = siren.geometry.Box(1.0, 2.0, 3.0)
-    assert any(issubclass(x.category, DeprecationWarning) for x in w)
-    assert box.X == 1.0 and box.Y == 2.0 and box.Z == 3.0
+def test_positional_box_raises():
+    """Box(x, y, z) raises with the widths=/center= fix-it."""
+    with pytest.raises(siren.errors.ConfigurationError, match="widths="):
+        siren.geometry.Box(1.0, 2.0, 3.0)
 
 
 def test_widths_center_box_places_at_center():

--- a/tests/python/test_visualization.py
+++ b/tests/python/test_visualization.py
@@ -34,7 +34,7 @@ def test_solid_xml_box_emits_full_widths():
     from siren import visualization
     from siren.geometry import Box
 
-    box = Box(2.0, 4.0, 6.0)
+    box = Box(widths=(2.0, 4.0, 6.0))
     el = ET.fromstring(visualization._solid_xml(box, "TESTBOX"))
     assert el.tag == "box"
     assert float(el.get("x")) == pytest.approx(2.0)


### PR DESCRIPTION
This PR makes positional Box construction raise ConfigurationError rather
than silently placing geometry at the origin, and adds three user-facing
documents: a runnable quickstart (DecayModel + check_closure + Simulation
walkthrough), a units-and-conventions reference (GeV/meters/ns, full-width
geometry arguments, frames, the two-stream RNG reproducibility contract,
and the serialization-restarts-streams rule), and an error-anchor index
covering every doc anchor referenced by engine exception messages.

Earlier revisions of this stack also carried the python channel builders'
switch to the ThreeBodyMode keyword constructors here; the builders are now
born keyword-native in the PRs that introduce them (#169, #172), so this PR
is docs plus the Box error surface.

At this PR's boundary: the build is green; pytest 812 passed, 25 skipped, 26 warnings; the golden
archive is byte-identical.

Supersedes #167 (`pr/naming-docs-cleanup`); pre-rewrite history is preserved
at tag `archive/v1/naming-docs-cleanup`.

Note: this branch's history was consolidated a second time after review
began; line-anchored review comments (from either round) may reference
superseded line numbers.


The error reference has also been expanded for the richer phase-space measure semantics. It documents directional density convertibility, the integrated-to-explicit azimuth lift, why explicit-to-integrated conversion is not pointwise, common-measure election, and the explicit physical-adapter convention override.