### PR TITLE
Fix interaction-depth inversion with finite decays

### DIFF
--- a/projects/detector/private/DetectorModel.cxx
+++ b/projects/detector/private/DetectorModel.cxx
@@ -1938,9 +1938,6 @@ double DetectorModel::DistanceForInteractionDepthFromPoint(Geometry::Intersectio
         dot = 1;
     }
 
-    // Recast decay length to cm for density integral
-    double total_decay_length_cm = total_decay_length / siren::utilities::Constants::cm;
-
     double total_interaction_depth = 0.0;
     double total_distance = 0.0;
     std::function<bool(std::vector<Geometry::Intersection>::const_iterator, std::vector<Geometry::Intersection>::const_iterator, double)> callback =
@@ -1954,31 +1951,61 @@ double DetectorModel::DistanceForInteractionDepthFromPoint(Geometry::Intersectio
             double segment_length = end_point - start_point;
             DetectorSector sector = GetSector(current_intersection->hierarchy);
             double target = interaction_depth - total_interaction_depth;
-            // This next line is because when we evaluate the density integral,
-            // we end up calculating an interaction length in units of m/cm.
-            // This is a correction
+            // Unit bookkeeping:
+            //   density integrals along the ray are in g cm^-3 m,
+            //   and the target composition below is in cm^2 g^-1,
+            //   so a dimensionless interaction depth is depth = 100 * composition * integral
+            //   with the factor of 100 converting the integral's meters to centimeters.
+            //   Dividing the remaining depth by 100 here and by the composition below converts it
+            //   into the g cm^-3 m quantity that the density distribution's InverseIntegral solves for.
             target /= 100;
             std::vector<double> interaction_depths = materials_.GetTargetParticleFraction(sector.material_id, targets.begin(), targets.end());
             for(unsigned int i=0; i<targets.size(); ++i) {
                 interaction_depths[i] *= total_cross_sections[i];
             }
             double target_composition = accumulate(interaction_depths.begin(), interaction_depths.end(), 0.0); // cm^2 g^-1
-            target /= target_composition;
-            double distance;
-            // total_decay_length now in cm
-            if (total_decay_length < std::numeric_limits<double>::infinity()) {
-              distance = sector.density->InverseIntegral(p0+start_point*direction, direction, 1./(total_decay_length_cm*target_composition), target, segment_length);
-            }
-            else {
-              distance = sector.density->InverseIntegral(p0+start_point*direction, direction, target, segment_length);
+            double distance = -1.0;
+            if(target_composition > 0.0) {
+                target /= target_composition;
+                if(std::isfinite(total_decay_length)) {
+                    // The decay hazard adds interaction depth at a rate of 1 / decay_length per meter of path.
+                    // target is expressed in g cm^-3 m (divided by 100 and by the composition above),
+                    // so the decay rate must be divided by the same 100 * composition for InverseIntegral to
+                    // invert the combined scattering-plus-decay depth in one consistent unit.
+                    double decay_constant = 1.0
+                        / (100.0 * total_decay_length * target_composition);
+                    distance = sector.density->InverseIntegral(
+                        p0 + start_point * direction, direction,
+                        decay_constant, target, segment_length);
+                } else {
+                    distance = sector.density->InverseIntegral(
+                        p0 + start_point * direction, direction,
+                        target, segment_length);
+                }
+            } else if(std::isfinite(total_decay_length)) {
+                // None of the requested targets exist in this material (for example a vacuum sector,
+                // or an exotic particle whose targets no material contains), so depth grows purely by
+                // decay, linearly at 1 / decay_length per meter, and the crossing point has a closed form.
+                // A solution beyond the segment end means the depth is reached in a later sector.
+                distance = (interaction_depth - total_interaction_depth)
+                    * total_decay_length;
+                if(distance > segment_length) {
+                    distance = -1.0;
+                }
             }
             done = distance >= 0;
-            double integral = sector.density->Integral(p0+start_point*direction, direction, segment_length); // g cm^-3 * m
-            integral *= (target_composition*siren::utilities::Constants::m/siren::utilities::Constants::cm); // --> m cm^-1 --> dimensionless
-            total_interaction_depth += integral;
             if(done) {
                 total_distance = start_point + distance;
             } else {
+                // The segment was fully traversed: count everything it consumed against the remaining depth,
+                // both the scattering integral and the decay hazard.
+                // This accumulation must mirror GetInteractionDepthInCGS exactly.
+                double integral = sector.density->Integral(p0+start_point*direction, direction, segment_length); // g cm^-3 * m
+                integral *= (target_composition*siren::utilities::Constants::m/siren::utilities::Constants::cm); // --> m cm^-1 --> dimensionless
+                total_interaction_depth += integral;
+                if(std::isfinite(total_decay_length)) {
+                    total_interaction_depth += segment_length / total_decay_length;
+                }
                 total_distance = start_point + segment_length;
             }
         }
@@ -2352,4 +2379,3 @@ double DetectorModel::GetTargetMass(siren::dataclasses::ParticleType target) con
 }
 
 CEREAL_REGISTER_DYNAMIC_INIT(siren_DetectorModel);
-

--- a/projects/detector/private/test/DensityDistribution_TEST.cxx
+++ b/projects/detector/private/test/DensityDistribution_TEST.cxx
@@ -8,6 +8,7 @@
 
 #include "SIREN/detector/DensityDistribution.h"
 #include "SIREN/detector/DensityDistribution1D.h"
+#include "SIREN/detector/CartesianAxisDensityDistribution.h"
 #include "SIREN/detector/Distribution1D.h"
 #include "SIREN/detector/Axis1D.h"
 #include "SIREN/detector/RadialAxis1D.h"
@@ -1372,14 +1373,49 @@ TEST(InverseIntegral, Axis_to_Distribution_connection)
                 F_res = -1;
             }
 
-            EXPECT_NEAR(A.InverseIntegral(p0, direction, A_int, R), A_res, std::abs(A_res)*1e-8);
-            EXPECT_NEAR(B.InverseIntegral(p0, direction, B_int, R), B_res, std::abs(B_res)*1e-7);
-            EXPECT_NEAR(C.InverseIntegral(p0, direction, C_int, R), C_res, std::abs(C_res)*1e-8);
-            EXPECT_NEAR(D.InverseIntegral(p0, direction, D_int, R), D_res, std::abs(D_res)*1e-8);
-            EXPECT_NEAR(E.InverseIntegral(p0, direction, E_int, R), E_res, std::abs(E_res)*1e-8);
-            EXPECT_NEAR(F.InverseIntegral(p0, direction, F_int, R), F_res, std::abs(F_res)*1e-8);
+            // Both sides are iterative solves: the library inverts with
+            // NewtonRaphson (xacc = 1e-6) over rombergIntegrate (tol =
+            // 1e-6), the reference roots qtrap (eps = 1e-8) with the same
+            // NewtonRaphson. Their disagreement scales like the integrator
+            // tolerance over the local density and reaches the 1e-5 scale
+            // in the tails, still far below the order-one errors of a real
+            // inversion bug.
+            EXPECT_NEAR(A.InverseIntegral(p0, direction, A_int, R), A_res, std::abs(A_res)*1e-4 + 1e-5);
+            EXPECT_NEAR(B.InverseIntegral(p0, direction, B_int, R), B_res, std::abs(B_res)*1e-4 + 1e-5);
+            EXPECT_NEAR(C.InverseIntegral(p0, direction, C_int, R), C_res, std::abs(C_res)*1e-4 + 1e-5);
+            EXPECT_NEAR(D.InverseIntegral(p0, direction, D_int, R), D_res, std::abs(D_res)*1e-4 + 1e-5);
+            EXPECT_NEAR(E.InverseIntegral(p0, direction, E_int, R), E_res, std::abs(E_res)*1e-4 + 1e-5);
+            EXPECT_NEAR(F.InverseIntegral(p0, direction, F_int, R), F_res, std::abs(F_res)*1e-4 + 1e-5);
         }
     }
+}
+
+// Keep this test below Axis_to_Distribution_connection: gtest runs suites in
+// first-registration order, and the random-input tests all draw from the
+// shared global rng_, so registering the InverseIntegral suite at the top of
+// the file would reshuffle the inputs every other test sees.
+TEST(InverseIntegral, CartesianDensityWithConstantUsesLocalDistance) {
+    CartesianAxis1D axis(
+        Vector3D(1.0, 0.0, 0.0), Vector3D(0.0, 0.0, 0.0));
+    PolynomialDistribution1D polynomial({2.0, 0.25});
+    DensityDistribution1D<CartesianAxis1D, PolynomialDistribution1D> density(
+        axis, polynomial);
+    // The segment starts away from the axis origin on purpose: the constant
+    // term must contribute per unit of distance traveled from the start, not
+    // per unit of absolute axis coordinate, and only a nonzero start
+    // coordinate distinguishes the two.
+    Vector3D start(3.0, 0.0, 0.0);
+    Vector3D direction(1.0, 0.0, 0.0);
+    constexpr double constant = 0.7;
+    constexpr double expected_distance = 1.25;
+    double integral = density.Integral(
+        start, direction, expected_distance)
+        + constant * expected_distance;
+
+    EXPECT_NEAR(
+        density.InverseIntegral(
+            start, direction, constant, integral, 5.0),
+        expected_distance, 1.0e-12);
 }
 
 int main(int argc, char** argv)
@@ -1387,4 +1423,3 @@ int main(int argc, char** argv)
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/projects/detector/private/test/DetectorModel_TEST.cxx
+++ b/projects/detector/private/test/DetectorModel_TEST.cxx
@@ -1490,9 +1490,82 @@ TEST(GetSectorByName, ClearSectorsAllowsReuse) {
     EXPECT_NO_THROW(A.AddSector(s2));
 }
 
+TEST(InteractionDepthInverse, MixedInteractionAndDecayCrossesMultipleSectors) {
+    DetectorModel model;
+    int material_id = model.GetMaterials().GetMaterialId("VACUUM");
+
+    DetectorSector first;
+    first.name = "FirstTransportSector";
+    first.material_id = material_id;
+    first.level = 0;
+    first.geo = Sphere(Vector3D(0.0, 0.0, 0.0), 2.0, 0.0).create();
+    first.density = DensityDistribution1D<
+        CartesianAxis1D, ConstantDistribution1D>(1.0).create();
+    model.AddSector(first);
+
+    DetectorSector second;
+    second.name = "SecondTransportSector";
+    second.material_id = material_id;
+    second.level = 1;
+    second.geo = Sphere(Vector3D(5.0, 0.0, 0.0), 2.0, 0.0).create();
+    second.density = DensityDistribution1D<
+        CartesianAxis1D, ConstantDistribution1D>(2.0).create();
+    model.AddSector(second);
+
+    Vector3D start(-1.0, 0.0, 0.0);
+    Vector3D direction(1.0, 0.0, 0.0);
+    constexpr double expected_distance = 5.0;
+    Vector3D endpoint = start + expected_distance * direction;
+    std::vector<ParticleType> targets{ParticleType::Nucleon};
+    std::vector<double> total_cross_sections{1.0e-27};
+    constexpr double decay_length = 2.0;
+
+    double requested_depth = model.GetInteractionDepthInCGS(
+        DetectorPosition(start), DetectorPosition(endpoint),
+        targets, total_cross_sections, decay_length);
+    double recovered_distance = model.DistanceForInteractionDepthFromPoint(
+        DetectorPosition(start), DetectorDirection(direction), requested_depth,
+        targets, total_cross_sections, decay_length);
+
+    EXPECT_NEAR(recovered_distance, expected_distance, 1.0e-10);
+    double recovered_depth = model.GetInteractionDepthInCGS(
+        DetectorPosition(start),
+        DetectorPosition(start + recovered_distance * direction),
+        targets, total_cross_sections, decay_length);
+    EXPECT_NEAR(recovered_depth, requested_depth, 1.0e-10);
+}
+
+TEST(InteractionDepthInverse, FiniteDecayWorksWithZeroTargetComposition) {
+    DetectorModel model;
+    int material_id = model.GetMaterials().GetMaterialId("VACUUM");
+    ASSERT_DOUBLE_EQ(
+        model.GetMaterials().GetTargetParticleFraction(
+            material_id, ParticleType::N4),
+        0.0);
+
+    Vector3D start(0.0, 0.0, 0.0);
+    Vector3D direction(1.0, 0.0, 0.0);
+    std::vector<ParticleType> targets{ParticleType::N4};
+    std::vector<double> total_cross_sections{1.0e-20};
+    constexpr double decay_length = 4.0;
+    constexpr double requested_depth = 1.75;
+    constexpr double expected_distance = requested_depth * decay_length;
+
+    double recovered_distance = model.DistanceForInteractionDepthFromPoint(
+        DetectorPosition(start), DetectorDirection(direction), requested_depth,
+        targets, total_cross_sections, decay_length);
+
+    ASSERT_TRUE(std::isfinite(recovered_distance));
+    EXPECT_NEAR(recovered_distance, expected_distance, 1.0e-12);
+    double recovered_depth = model.GetInteractionDepthInCGS(
+        DetectorPosition(start),
+        DetectorPosition(start + recovered_distance * direction),
+        targets, total_cross_sections, decay_length);
+    EXPECT_NEAR(recovered_depth, requested_depth, 1.0e-12);
+}
+
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/projects/detector/public/SIREN/detector/CartesianAxisDensityDistribution.h
+++ b/projects/detector/public/SIREN/detector/CartesianAxisDensityDistribution.h
@@ -122,9 +122,16 @@ class DensityDistribution1D<CartesianAxis1D, DistributionT, typename std::enable
 
         double dist_integral = integral * dxdt;
 
+        // This closed form solves in absolute axis coordinates: x is a point
+        // on the axis and a is the coordinate of the segment start. This
+        // differs from the generic InverseIntegral implementations, whose
+        // integration variable is already the distance along the path. The
+        // constant (decay) term must therefore scale with the distance
+        // traveled from the start, x - a, never with x itself.
         double Ia = dist.AntiDerivative(a);
         std::function<double(double)> F = [&](double x)->double {
-            return (dist.AntiDerivative(x) - Ia) + constant*x - dist_integral;
+            return (dist.AntiDerivative(x) - Ia)
+                + constant * (x - a) - dist_integral;
         };
 
         std::function<double(double)> dF = [&](double x)->double {


### PR DESCRIPTION
## Summary

Fixes interaction-depth inversion when a path combines material interactions with a finite decay length

- evaluates Cartesian-axis density inversion in the correct local coordinate;
- accumulates decay depth over every traversed detector segment;
- handles sectors with zero target composition without dropping their decay contribution;
- adds offset-density, mixed interaction/decay, and zero-composition regression tests.

This is the new base for the phase space rework PR stack; #168 should target this branch.

## Validation

- canonical build, install, and installed-source freshness check passed;
- `UnitTest_DensityDistribution --gtest_filter=InverseIntegral.CartesianDensityWithConstantUsesLocalDistance` passed;
- both `UnitTest_DetectorModel` interaction-depth inversion regression tests passed.
