### PR TITLE
Interactions: pass-through TrivialCrossSection with tabulated totals

### DIFF
--- a/projects/interactions/CMakeLists.txt
+++ b/projects/interactions/CMakeLists.txt
@@ -17,6 +17,7 @@ LIST (APPEND interactions_SOURCES
     ${PROJECT_SOURCE_DIR}/projects/interactions/private/ElectroweakDecay.cxx
     ${PROJECT_SOURCE_DIR}/projects/interactions/private/ElasticScattering.cxx
     ${PROJECT_SOURCE_DIR}/projects/interactions/private/DummyCrossSection.cxx
+    ${PROJECT_SOURCE_DIR}/projects/interactions/private/TrivialCrossSection.cxx
     ${PROJECT_SOURCE_DIR}/projects/interactions/private/pyDarkNewsCrossSection.cxx
     ${PROJECT_SOURCE_DIR}/projects/interactions/private/pyDarkNewsDecay.cxx
     ${PROJECT_SOURCE_DIR}/projects/interactions/private/CharmMesonDecay.cxx
@@ -130,3 +131,7 @@ if(TARGET PYTHIA8)
     target_compile_definitions(UnitTest_PythiaDISCharmClosure PRIVATE SIREN_HAS_PYTHIA8)
     target_link_libraries(UnitTest_PythiaDISCharmClosure PYTHIA8)
 endif()
+
+# Pass-through cross section with tabulated totals (generation stand-in /
+# generator-deferred physical totals).
+package_add_test(UnitTest_TrivialCrossSection ${PROJECT_SOURCE_DIR}/projects/interactions/private/test/TrivialCrossSection_TEST.cxx)

--- a/projects/interactions/private/TrivialCrossSection.cxx
+++ b/projects/interactions/private/TrivialCrossSection.cxx
@@ -1,0 +1,187 @@
+#include "SIREN/interactions/TrivialCrossSection.h"
+
+#include <tuple>                                              // for tie
+#include <string>                                             // for basic_s...
+#include <vector>                                             // for vector
+#include <algorithm>                                          // for find
+#include <stdexcept>                                          // for runtime...
+
+#include "SIREN/interactions/CrossSection.h"         // for CrossSe...
+#include "SIREN/dataclasses/InteractionRecord.h"     // for Interac...
+#include "SIREN/dataclasses/InteractionSignature.h"  // for Interac...
+#include "SIREN/dataclasses/Particle.h"              // for Particle
+#include "SIREN/utilities/Random.h"                  // for SIREN_r...
+
+namespace siren {
+namespace interactions {
+
+TrivialCrossSection::TrivialCrossSection(double cross_section_cm2,
+        std::vector<siren::dataclasses::ParticleType> primary_types,
+        std::vector<siren::dataclasses::ParticleType> target_types)
+    : targets_(std::move(target_types)) {
+    if(not (cross_section_cm2 > 0))
+        throw std::runtime_error("TrivialCrossSection: the cross section must be positive");
+    if(primary_types.empty())
+        throw std::runtime_error("TrivialCrossSection: need at least one primary type");
+    if(targets_.empty())
+        throw std::runtime_error("TrivialCrossSection: need at least one target type");
+    for(auto primary : primary_types) {
+        energies_[primary] = {0.0, 1e9};
+        cross_sections_[primary] = {cross_section_cm2, cross_section_cm2};
+    }
+}
+
+TrivialCrossSection::TrivialCrossSection(std::map<siren::dataclasses::ParticleType,
+            std::pair<std::vector<double>, std::vector<double>>> tables,
+        std::vector<siren::dataclasses::ParticleType> target_types)
+    : targets_(std::move(target_types)) {
+    if(tables.empty())
+        throw std::runtime_error("TrivialCrossSection: need at least one primary table");
+    if(targets_.empty())
+        throw std::runtime_error("TrivialCrossSection: need at least one target type");
+    for(auto & entry : tables) {
+        std::vector<double> & energies = entry.second.first;
+        std::vector<double> & cross_sections = entry.second.second;
+        if(energies.empty())
+            throw std::runtime_error("TrivialCrossSection: a table must have at least one point");
+        if(energies.size() != cross_sections.size())
+            throw std::runtime_error("TrivialCrossSection: energies and cross sections must have the same length");
+        for(size_t i = 0; i + 1 < energies.size(); ++i) {
+            if(not (energies[i] < energies[i + 1]))
+                throw std::runtime_error("TrivialCrossSection: energies must be strictly ascending");
+        }
+        for(double xs : cross_sections) {
+            if(xs < 0)
+                throw std::runtime_error("TrivialCrossSection: cross sections must be non-negative");
+        }
+        energies_[entry.first] = std::move(energies);
+        cross_sections_[entry.first] = std::move(cross_sections);
+    }
+}
+
+bool TrivialCrossSection::equal(CrossSection const & other) const {
+    const TrivialCrossSection* x = dynamic_cast<const TrivialCrossSection*>(&other);
+
+    if(!x)
+        return false;
+    else
+        return std::tie(energies_, cross_sections_, targets_)
+            == std::tie(x->energies_, x->cross_sections_, x->targets_);
+}
+
+double TrivialCrossSection::TotalCrossSection(siren::dataclasses::ParticleType primary, double energy) const {
+    auto it = energies_.find(primary);
+    if(it == energies_.end())
+        return 0.0;
+    std::vector<double> const & energies = it->second;
+    std::vector<double> const & cross_sections = cross_sections_.at(primary);
+    if(energy < energies.front())
+        return 0.0;
+    if(energy >= energies.back())
+        return cross_sections.back();
+    size_t i = std::distance(energies.begin(),
+            std::upper_bound(energies.begin(), energies.end(), energy)) - 1;
+    double t = (energy - energies[i]) / (energies[i + 1] - energies[i]);
+    return cross_sections[i] + t * (cross_sections[i + 1] - cross_sections[i]);
+}
+
+double TrivialCrossSection::TotalCrossSection(dataclasses::InteractionRecord const & interaction) const {
+    return TotalCrossSection(interaction.signature.primary_type, interaction.primary_momentum[0]);
+}
+
+double TrivialCrossSection::DifferentialCrossSection(dataclasses::InteractionRecord const & interaction) const {
+    siren::dataclasses::InteractionSignature const & signature = interaction.signature;
+    bool matches = energies_.count(signature.primary_type) > 0
+        and std::find(targets_.begin(), targets_.end(), signature.target_type) != targets_.end()
+        and signature.secondary_types.size() == 2
+        and signature.secondary_types[0] == signature.primary_type
+        and signature.secondary_types[1] == signature.target_type;
+    if(not matches)
+        return 0.0;
+    return TotalCrossSection(interaction);
+}
+
+double TrivialCrossSection::InteractionThreshold(dataclasses::InteractionRecord const & interaction) const {
+    auto it = energies_.find(interaction.signature.primary_type);
+    if(it == energies_.end())
+        return 0.0;
+    return it->second.front();
+}
+
+void TrivialCrossSection::SampleFinalState(dataclasses::CrossSectionDistributionRecord & record, std::shared_ptr<siren::utilities::SIREN_random>) const {
+    std::vector<siren::dataclasses::SecondaryParticleRecord> & secondaries = record.GetSecondaryParticleRecords();
+
+    siren::dataclasses::SecondaryParticleRecord & neutrino = secondaries[0];
+    neutrino.SetFourMomentum({record.primary_momentum[0], record.primary_momentum[1],
+                              record.primary_momentum[2], record.primary_momentum[3]});
+    neutrino.SetMass(record.primary_mass);
+    neutrino.SetHelicity(record.primary_helicity);
+
+    siren::dataclasses::SecondaryParticleRecord & target = secondaries[1];
+    target.SetFourMomentum({record.target_mass, 0.0, 0.0, 0.0});
+    target.SetMass(record.target_mass);
+    target.SetHelicity(record.target_helicity);
+}
+
+double TrivialCrossSection::FinalStateProbability(dataclasses::InteractionRecord const & interaction) const {
+    double dxs = DifferentialCrossSection(interaction);
+    double txs = TotalCrossSection(interaction);
+    if(dxs == 0) {
+        return 0.0;
+    } else {
+        return dxs / txs;
+    }
+}
+
+std::vector<siren::dataclasses::ParticleType> TrivialCrossSection::GetPossibleTargets() const {
+    return targets_;
+}
+
+std::vector<siren::dataclasses::ParticleType> TrivialCrossSection::GetPossibleTargetsFromPrimary(siren::dataclasses::ParticleType primary_type) const {
+    if(energies_.count(primary_type) == 0)
+        return {};
+    return targets_;
+}
+
+std::vector<siren::dataclasses::ParticleType> TrivialCrossSection::GetPossiblePrimaries() const {
+    std::vector<siren::dataclasses::ParticleType> primaries;
+    primaries.reserve(energies_.size());
+    for(auto const & entry : energies_)
+        primaries.push_back(entry.first);
+    return primaries;
+}
+
+std::vector<dataclasses::InteractionSignature> TrivialCrossSection::GetPossibleSignatures() const {
+    std::vector<siren::dataclasses::InteractionSignature> signatures;
+    for(auto const & entry : energies_) {
+        for(auto target : targets_) {
+            siren::dataclasses::InteractionSignature signature;
+            signature.primary_type = entry.first;
+            signature.target_type = target;
+            signature.secondary_types = {entry.first, target};
+            signatures.push_back(signature);
+        }
+    }
+    return signatures;
+}
+
+std::vector<dataclasses::InteractionSignature> TrivialCrossSection::GetPossibleSignaturesFromParents(siren::dataclasses::ParticleType primary_type, siren::dataclasses::ParticleType target_type) const {
+    std::vector<siren::dataclasses::InteractionSignature> signatures;
+    if(energies_.count(primary_type) == 0)
+        return signatures;
+    if(std::find(targets_.begin(), targets_.end(), target_type) == targets_.end())
+        return signatures;
+    siren::dataclasses::InteractionSignature signature;
+    signature.primary_type = primary_type;
+    signature.target_type = target_type;
+    signature.secondary_types = {primary_type, target_type};
+    signatures.push_back(signature);
+    return signatures;
+}
+
+std::vector<std::string> TrivialCrossSection::DensityVariables() const {
+    return std::vector<std::string>{};
+}
+
+} // namespace interactions
+} // namespace siren

--- a/projects/interactions/private/pybindings/TrivialCrossSection.h
+++ b/projects/interactions/private/pybindings/TrivialCrossSection.h
@@ -1,0 +1,43 @@
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/operators.h>
+#include <pybind11/stl.h>
+
+#include "../../public/SIREN/interactions/CrossSection.h"
+#include "../../public/SIREN/interactions/TrivialCrossSection.h"
+#include "../../../dataclasses/public/SIREN/dataclasses/Particle.h"
+#include "../../../dataclasses/public/SIREN/dataclasses/InteractionRecord.h"
+#include "../../../dataclasses/public/SIREN/dataclasses/InteractionSignature.h"
+#include "../../../geometry/public/SIREN/geometry/Geometry.h"
+#include "../../../utilities/public/SIREN/utilities/Random.h"
+
+void register_TrivialCrossSection(pybind11::module_ & m) {
+    using namespace pybind11;
+    using namespace siren::interactions;
+
+    class_<TrivialCrossSection, std::shared_ptr<TrivialCrossSection>, CrossSection> trivialcrosssection(m, "TrivialCrossSection");
+
+    trivialcrosssection
+        .def(init<double, std::vector<siren::dataclasses::ParticleType>, std::vector<siren::dataclasses::ParticleType>>(),
+                arg("cross_section_cm2"), arg("primary_types"), arg("target_types"))
+        .def(init<std::map<siren::dataclasses::ParticleType, std::pair<std::vector<double>, std::vector<double>>>, std::vector<siren::dataclasses::ParticleType>>(),
+                arg("tables"), arg("target_types"))
+        .def("_equal", &TrivialCrossSection::equal)
+        .def("TotalCrossSection",overload_cast<siren::dataclasses::InteractionRecord const &>(&TrivialCrossSection::TotalCrossSection, const_))
+        .def("TotalCrossSection",overload_cast<siren::dataclasses::ParticleType, double>(&TrivialCrossSection::TotalCrossSection, const_))
+        .def("DifferentialCrossSection",overload_cast<siren::dataclasses::InteractionRecord const &>(&TrivialCrossSection::DifferentialCrossSection, const_))
+        .def("InteractionThreshold",&TrivialCrossSection::InteractionThreshold)
+        .def("GetPossibleTargets",&TrivialCrossSection::GetPossibleTargets)
+        .def("GetPossibleTargetsFromPrimary",&TrivialCrossSection::GetPossibleTargetsFromPrimary)
+        .def("GetPossiblePrimaries",&TrivialCrossSection::GetPossiblePrimaries)
+        .def("GetPossibleSignatures",&TrivialCrossSection::GetPossibleSignatures)
+        .def("GetPossibleSignaturesFromParents",&TrivialCrossSection::GetPossibleSignaturesFromParents)
+        .def("FinalStateProbability",&TrivialCrossSection::FinalStateProbability)
+        .def("DensityVariables",&TrivialCrossSection::DensityVariables)
+        ;
+}

--- a/projects/interactions/private/pybindings/interactions.cxx
+++ b/projects/interactions/private/pybindings/interactions.cxx
@@ -9,6 +9,7 @@
 #include "../../public/SIREN/interactions/DISFromSpline.h"
 #include "../../public/SIREN/interactions/DummyCrossSection.h"
 #include "../../public/SIREN/interactions/ElasticScattering.h"
+#include "../../public/SIREN/interactions/TrivialCrossSection.h"
 #include "../../public/SIREN/interactions/ElectroweakDecay.h"
 #include "../../public/SIREN/interactions/HNLDipoleDecay.h"
 #include "../../public/SIREN/interactions/HNLDipoleFromTable.h"
@@ -34,6 +35,7 @@
 #include "./Decay.h"
 #include "./DummyCrossSection.h"
 //#include "./ElasticScattering.h"
+#include "./TrivialCrossSection.h"
 #include "./ElectroweakDecay.h"
 #include "./HNLDipoleDecay.h"
 #include "./HNLDipoleFromTable.h"
@@ -66,6 +68,7 @@ PYBIND11_MODULE(interactions,m) {
     register_DISFromSpline(m);
     register_DummyCrossSection(m);
     //register_ElasticScattering();
+    register_TrivialCrossSection(m);
     register_ElectroweakDecay(m);
     register_HNLDipoleDecay(m);
     register_HNLDipoleFromTable(m);

--- a/projects/interactions/private/test/TrivialCrossSection_TEST.cxx
+++ b/projects/interactions/private/test/TrivialCrossSection_TEST.cxx
@@ -1,0 +1,188 @@
+// TrivialCrossSection invariants: tabulated total cross section
+// (interpolation, threshold, clamping), exact pass-through final-state
+// kinematics, unit final-state probability for matching signatures, signature
+// filtering by both primary and target, and equality-preserving polymorphic
+// serialization.
+
+#include <cmath>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <cereal/archives/json.hpp>
+
+#include <gtest/gtest.h>
+
+#include "SIREN/interactions/CrossSection.h"
+#include "SIREN/interactions/TrivialCrossSection.h"
+#include "SIREN/dataclasses/InteractionRecord.h"
+#include "SIREN/dataclasses/InteractionSignature.h"
+#include "SIREN/dataclasses/Particle.h"
+#include "SIREN/utilities/Random.h"
+
+using namespace siren::interactions;
+using namespace siren::dataclasses;
+
+namespace {
+
+InteractionRecord MakeRecord(double energy,
+        ParticleType primary = ParticleType::NuMu,
+        ParticleType target = ParticleType::Nucleon) {
+    InteractionRecord record;
+    record.signature.primary_type = primary;
+    record.signature.target_type = target;
+    record.signature.secondary_types = {primary, target};
+    record.primary_momentum = {energy, 0.0, 0.0, energy};
+    record.primary_mass = 0.0;
+    record.primary_helicity = -0.5;
+    record.target_mass = 0.939;
+    record.target_helicity = 0.5;
+    record.interaction_vertex = {0.0, 0.0, 0.0};
+    return record;
+}
+
+std::shared_ptr<TrivialCrossSection> MakeTabulated() {
+    std::map<ParticleType, std::pair<std::vector<double>, std::vector<double>>> tables;
+    tables[ParticleType::NuMu] = {{1.0, 3.0}, {2e-38, 6e-38}};
+    return std::make_shared<TrivialCrossSection>(tables,
+            std::vector<ParticleType>{ParticleType::Nucleon});
+}
+
+} // namespace
+
+TEST(TrivialCrossSection, ConstantTable) {
+    TrivialCrossSection xs(1e-38,
+            {ParticleType::NuMu, ParticleType::NuE},
+            {ParticleType::Nucleon});
+    EXPECT_DOUBLE_EQ(1e-38, xs.TotalCrossSection(ParticleType::NuMu, 0.5));
+    EXPECT_DOUBLE_EQ(1e-38, xs.TotalCrossSection(ParticleType::NuE, 100.0));
+    EXPECT_DOUBLE_EQ(0.0, xs.TotalCrossSection(ParticleType::NuTau, 1.0));
+    EXPECT_DOUBLE_EQ(0.0, xs.InteractionThreshold(MakeRecord(1.0)));
+}
+
+TEST(TrivialCrossSection, InterpolationThresholdClamp) {
+    std::shared_ptr<TrivialCrossSection> xs = MakeTabulated();
+    // Knots reproduce exactly; midpoints interpolate linearly.
+    EXPECT_DOUBLE_EQ(2e-38, xs->TotalCrossSection(ParticleType::NuMu, 1.0));
+    EXPECT_DOUBLE_EQ(4e-38, xs->TotalCrossSection(ParticleType::NuMu, 2.0));
+    // Below the first knot the cross section vanishes and the threshold
+    // reports the first knot.
+    EXPECT_DOUBLE_EQ(0.0, xs->TotalCrossSection(ParticleType::NuMu, 0.5));
+    EXPECT_DOUBLE_EQ(1.0, xs->InteractionThreshold(MakeRecord(0.5)));
+    // Above the last knot the value clamps.
+    EXPECT_DOUBLE_EQ(6e-38, xs->TotalCrossSection(ParticleType::NuMu, 10.0));
+    // Record-based lookup uses the primary energy.
+    EXPECT_DOUBLE_EQ(4e-38, xs->TotalCrossSection(MakeRecord(2.0)));
+}
+
+TEST(TrivialCrossSection, InvalidConstruction) {
+    EXPECT_THROW(TrivialCrossSection(0.0, {ParticleType::NuMu}, {ParticleType::Nucleon}),
+            std::runtime_error);
+    EXPECT_THROW(TrivialCrossSection(1e-38, {}, {ParticleType::Nucleon}),
+            std::runtime_error);
+    EXPECT_THROW(TrivialCrossSection(1e-38, {ParticleType::NuMu}, {}),
+            std::runtime_error);
+    std::map<ParticleType, std::pair<std::vector<double>, std::vector<double>>> bad_order;
+    bad_order[ParticleType::NuMu] = {{3.0, 1.0}, {2e-38, 6e-38}};
+    EXPECT_THROW(TrivialCrossSection(bad_order, {ParticleType::Nucleon}),
+            std::runtime_error);
+    std::map<ParticleType, std::pair<std::vector<double>, std::vector<double>>> bad_length;
+    bad_length[ParticleType::NuMu] = {{1.0, 3.0}, {2e-38}};
+    EXPECT_THROW(TrivialCrossSection(bad_length, {ParticleType::Nucleon}),
+            std::runtime_error);
+}
+
+TEST(TrivialCrossSection, SignatureFiltering) {
+    std::shared_ptr<TrivialCrossSection> xs = MakeTabulated();
+
+    std::vector<InteractionSignature> signatures =
+        xs->GetPossibleSignaturesFromParents(ParticleType::NuMu, ParticleType::Nucleon);
+    ASSERT_EQ(1u, signatures.size());
+    EXPECT_EQ(ParticleType::NuMu, signatures[0].primary_type);
+    EXPECT_EQ(ParticleType::Nucleon, signatures[0].target_type);
+    ASSERT_EQ(2u, signatures[0].secondary_types.size());
+    EXPECT_EQ(ParticleType::NuMu, signatures[0].secondary_types[0]);
+    EXPECT_EQ(ParticleType::Nucleon, signatures[0].secondary_types[1]);
+
+    // Unconfigured primaries and targets produce no signatures.
+    EXPECT_TRUE(xs->GetPossibleSignaturesFromParents(ParticleType::NuE, ParticleType::Nucleon).empty());
+    EXPECT_TRUE(xs->GetPossibleSignaturesFromParents(ParticleType::NuMu, ParticleType::PPlus).empty());
+    EXPECT_TRUE(xs->GetPossibleTargetsFromPrimary(ParticleType::NuE).empty());
+
+    // The nucleus-target convention is expressible.
+    TrivialCrossSection argon(1e-38, {ParticleType::NuMu}, {ParticleType::Ar40Nucleus});
+    std::vector<InteractionSignature> argon_signatures =
+        argon.GetPossibleSignaturesFromParents(ParticleType::NuMu, ParticleType::Ar40Nucleus);
+    ASSERT_EQ(1u, argon_signatures.size());
+    EXPECT_EQ(ParticleType::Ar40Nucleus, argon_signatures[0].target_type);
+}
+
+TEST(TrivialCrossSection, FinalStateProbability) {
+    std::shared_ptr<TrivialCrossSection> xs = MakeTabulated();
+
+    // Matching signature: exactly unit probability.
+    EXPECT_DOUBLE_EQ(1.0, xs->FinalStateProbability(MakeRecord(2.0)));
+
+    // A record with different secondaries has zero probability.
+    InteractionRecord mismatched = MakeRecord(2.0);
+    mismatched.signature.secondary_types = {ParticleType::MuMinus, ParticleType::Hadrons};
+    EXPECT_DOUBLE_EQ(0.0, xs->FinalStateProbability(mismatched));
+
+    // Below threshold the total vanishes, so the probability is zero.
+    EXPECT_DOUBLE_EQ(0.0, xs->FinalStateProbability(MakeRecord(0.5)));
+}
+
+TEST(TrivialCrossSection, PassThroughKinematics) {
+    std::shared_ptr<TrivialCrossSection> xs = MakeTabulated();
+    std::shared_ptr<siren::utilities::SIREN_random> random =
+        std::make_shared<siren::utilities::SIREN_random>(1234);
+
+    InteractionRecord record = MakeRecord(2.0);
+    record.primary_momentum = {2.0, 0.3, -0.4, std::sqrt(2.0 * 2.0 - 0.3 * 0.3 - 0.4 * 0.4)};
+
+    CrossSectionDistributionRecord xsec_record(record);
+    xs->SampleFinalState(xsec_record, random);
+
+    InteractionRecord finalized = record;
+    xsec_record.Finalize(finalized);
+
+    ASSERT_EQ(2u, finalized.secondary_momenta.size());
+    for(size_t component = 0; component < 4; ++component) {
+        EXPECT_DOUBLE_EQ(record.primary_momentum[component],
+                finalized.secondary_momenta[0][component]);
+    }
+    EXPECT_DOUBLE_EQ(record.target_mass, finalized.secondary_momenta[1][0]);
+    EXPECT_DOUBLE_EQ(0.0, finalized.secondary_momenta[1][1]);
+    EXPECT_DOUBLE_EQ(0.0, finalized.secondary_momenta[1][2]);
+    EXPECT_DOUBLE_EQ(0.0, finalized.secondary_momenta[1][3]);
+}
+
+TEST(TrivialCrossSection, EqualAndSerialization) {
+    std::shared_ptr<TrivialCrossSection> xs = MakeTabulated();
+    std::shared_ptr<TrivialCrossSection> same = MakeTabulated();
+    TrivialCrossSection constant(1e-38, {ParticleType::NuMu}, {ParticleType::Nucleon});
+
+    EXPECT_TRUE(xs->equal(*same));
+    EXPECT_FALSE(xs->equal(constant));
+
+    std::stringstream ss;
+    {
+        cereal::JSONOutputArchive archive(ss);
+        std::shared_ptr<CrossSection> base = xs;
+        archive(base);
+    }
+    std::shared_ptr<CrossSection> loaded;
+    {
+        cereal::JSONInputArchive archive(ss);
+        archive(loaded);
+    }
+    ASSERT_TRUE(loaded);
+    EXPECT_TRUE(xs->equal(*loaded));
+    EXPECT_DOUBLE_EQ(4e-38, loaded->TotalCrossSection(MakeRecord(2.0)));
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/projects/interactions/public/SIREN/interactions/TrivialCrossSection.h
+++ b/projects/interactions/public/SIREN/interactions/TrivialCrossSection.h
@@ -1,0 +1,110 @@
+#pragma once
+#ifndef SIREN_TrivialCrossSection_H
+#define SIREN_TrivialCrossSection_H
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+#include <cstdint>
+#include <stdexcept>
+
+#include <cereal/cereal.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/map.hpp>
+#include <cereal/types/set.hpp>
+#include <cereal/types/vector.hpp>
+#include <cereal/types/polymorphic.hpp>
+#include <cereal/types/base_class.hpp>
+#include <cereal/types/utility.hpp>
+
+#include "SIREN/interactions/CrossSection.h"  // for CrossSection
+#include "SIREN/dataclasses/Particle.h"        // for Particle
+
+namespace siren { namespace dataclasses { class InteractionRecord; } }
+namespace siren { namespace dataclasses { class CrossSectionDistributionRecord; } }
+namespace siren { namespace dataclasses { struct InteractionSignature; } }
+namespace siren { namespace utilities { class SIREN_random; } }
+
+namespace siren {
+namespace interactions {
+
+// A configurable pass-through cross section. The final state is the primary
+// and the target unchanged, with unit final-state probability, so the physics
+// content is the total cross section alone. Intended for two roles: a
+// generation stand-in whose scale cancels in the event weight, and a physical
+// cross section whose total is tabulated from an external generator and
+// applied at weighting time.
+class TrivialCrossSection : public CrossSection {
+friend cereal::access;
+private:
+    // sigma(E) per primary type: ascending energies in GeV, values in cm^2.
+    // Linear interpolation between knots; zero below the first knot; clamped
+    // to the last value above the last knot.
+    std::map<siren::dataclasses::ParticleType, std::vector<double>> energies_;
+    std::map<siren::dataclasses::ParticleType, std::vector<double>> cross_sections_;
+    std::vector<siren::dataclasses::ParticleType> targets_;
+
+    TrivialCrossSection() = default;
+public:
+    // Constant cross section for every listed primary.
+    TrivialCrossSection(double cross_section_cm2,
+                        std::vector<siren::dataclasses::ParticleType> primary_types,
+                        std::vector<siren::dataclasses::ParticleType> target_types);
+    // Tabulated cross section per primary: {primary: (energies_GeV, sigma_cm2)}.
+    TrivialCrossSection(std::map<siren::dataclasses::ParticleType,
+                                 std::pair<std::vector<double>, std::vector<double>>> tables,
+                        std::vector<siren::dataclasses::ParticleType> target_types);
+
+    virtual bool equal(CrossSection const & other) const override;
+
+    double TotalCrossSection(dataclasses::InteractionRecord const &) const override;
+    double TotalCrossSection(siren::dataclasses::ParticleType primary, double energy) const;
+    double DifferentialCrossSection(dataclasses::InteractionRecord const &) const override;
+    double InteractionThreshold(dataclasses::InteractionRecord const &) const override;
+    void SampleFinalState(dataclasses::CrossSectionDistributionRecord &, std::shared_ptr<siren::utilities::SIREN_random> random) const override;
+
+    std::vector<siren::dataclasses::ParticleType> GetPossibleTargets() const override;
+    std::vector<siren::dataclasses::ParticleType> GetPossibleTargetsFromPrimary(siren::dataclasses::ParticleType primary_type) const override;
+    std::vector<siren::dataclasses::ParticleType> GetPossiblePrimaries() const override;
+    std::vector<dataclasses::InteractionSignature> GetPossibleSignatures() const override;
+    std::vector<dataclasses::InteractionSignature> GetPossibleSignaturesFromParents(siren::dataclasses::ParticleType primary_type, siren::dataclasses::ParticleType target_type) const override;
+
+    virtual double FinalStateProbability(dataclasses::InteractionRecord const & record) const override;
+
+    virtual std::vector<std::string> DensityVariables() const override;
+
+    template<typename Archive>
+    void save(Archive & archive, std::uint32_t const version) const {
+        if(version == 0) {
+            archive(::cereal::make_nvp("Energies", energies_));
+            archive(::cereal::make_nvp("CrossSections", cross_sections_));
+            archive(::cereal::make_nvp("Targets", targets_));
+            archive(cereal::virtual_base_class<CrossSection>(this));
+        } else {
+            throw std::runtime_error("TrivialCrossSection only supports version <= 0!");
+        }
+    }
+    template<typename Archive>
+    void load(Archive & archive, std::uint32_t version) {
+        if(version == 0) {
+            archive(::cereal::make_nvp("Energies", energies_));
+            archive(::cereal::make_nvp("CrossSections", cross_sections_));
+            archive(::cereal::make_nvp("Targets", targets_));
+            archive(cereal::virtual_base_class<CrossSection>(this));
+        } else {
+            throw std::runtime_error("TrivialCrossSection only supports version <= 0!");
+        }
+    }
+};
+
+} // namespace interactions
+} // namespace siren
+
+CEREAL_CLASS_VERSION(siren::interactions::TrivialCrossSection, 0);
+CEREAL_REGISTER_TYPE(siren::interactions::TrivialCrossSection);
+CEREAL_REGISTER_POLYMORPHIC_RELATION(siren::interactions::CrossSection, siren::interactions::TrivialCrossSection);
+
+#endif // SIREN_TrivialCrossSection_H

--- a/tests/python/test_trivial_cross_section.py
+++ b/tests/python/test_trivial_cross_section.py
@@ -1,0 +1,209 @@
+"""TrivialCrossSection driven through the injector and weighter.
+
+The class is a pass-through cross section whose physics content is the total
+cross section alone. Unit tests cover the tabulated total (interpolation,
+threshold, clamping) and the signature conventions. The end-to-end tests
+inject against the CCM detector model with a constant stand-in cross section
+and then weight the same events under two physical hypotheses, checking that
+the weight ratio is exactly the ratio of the physical total cross sections:
+the mechanism that defers the physical total to an external generator.
+"""
+import math as pymath
+import os
+
+import pytest
+
+siren = pytest.importorskip("siren")
+
+from siren import dataclasses as dc
+from siren import distributions
+from siren import injection
+from siren import interactions
+from siren import math as smath
+from siren import utilities
+from siren import _util
+
+NuMu = dc.Particle.ParticleType.NuMu
+NuE = dc.Particle.ParticleType.NuE
+Nucleon = dc.Particle.ParticleType.Nucleon
+Ar40Nucleus = dc.Particle.ParticleType.Ar40Nucleus
+
+SIGMA_CONST = 1.0e-38  # cm^2
+ENERGY_MIN = 0.5
+ENERGY_MAX = 5.0
+
+
+def _table_sigma(energy):
+    """Linear stand-in for a generator total: 0.7e-38 cm^2 per GeV."""
+    return 0.7e-38 * energy
+
+
+def _table_cross_section():
+    # Two knots suffice: linear interpolation reproduces _table_sigma exactly
+    # across the injected energy range.
+    return interactions.TrivialCrossSection(
+        {NuMu: ([0.1, 10.0], [_table_sigma(0.1), _table_sigma(10.0)])},
+        [Nucleon],
+    )
+
+
+def _constant_cross_section():
+    return interactions.TrivialCrossSection(SIGMA_CONST, [NuMu], [Nucleon])
+
+
+def _detector_model():
+    try:
+        dm = siren.detector.DetectorModel()
+        det_dir = _util.get_detector_model_path("CCM")
+        dm.LoadMaterialModel(os.path.join(det_dir, "materials.dat"))
+        dm.LoadDetectorModel(os.path.join(det_dir, "densities.dat"))
+    except Exception as e:  # detector model files not available in this env
+        pytest.skip(f"CCM detector model unavailable: {e}")
+    return dm
+
+
+@pytest.fixture(scope="module")
+def detector_model():
+    return _detector_model()
+
+
+# --- unit-level behavior ---
+
+
+def test_constant_cross_section_is_flat():
+    xs = _constant_cross_section()
+    assert xs.TotalCrossSection(NuMu, 0.5) == pytest.approx(SIGMA_CONST)
+    assert xs.TotalCrossSection(NuMu, 50.0) == pytest.approx(SIGMA_CONST)
+    assert xs.TotalCrossSection(NuE, 1.0) == 0.0
+
+
+def test_tabulated_cross_section_interpolates():
+    xs = _table_cross_section()
+    for energy in (0.1, 0.5, 1.0, 2.5, 10.0):
+        assert xs.TotalCrossSection(NuMu, energy) == pytest.approx(_table_sigma(energy))
+    # Below the first knot the total vanishes; above the last it clamps.
+    assert xs.TotalCrossSection(NuMu, 0.05) == 0.0
+    assert xs.TotalCrossSection(NuMu, 100.0) == pytest.approx(_table_sigma(10.0))
+
+
+def test_signatures_are_pass_through():
+    xs = _constant_cross_section()
+    signatures = xs.GetPossibleSignaturesFromParents(NuMu, Nucleon)
+    assert len(signatures) == 1
+    sig = signatures[0]
+    assert sig.primary_type == NuMu
+    assert sig.target_type == Nucleon
+    assert list(sig.secondary_types) == [NuMu, Nucleon]
+    assert xs.GetPossibleSignaturesFromParents(NuE, Nucleon) == []
+
+
+def test_nucleus_target_convention():
+    xs = interactions.TrivialCrossSection(SIGMA_CONST, [NuMu], [Ar40Nucleus])
+    signatures = xs.GetPossibleSignaturesFromParents(NuMu, Ar40Nucleus)
+    assert len(signatures) == 1
+    assert signatures[0].target_type == Ar40Nucleus
+
+
+def test_invalid_construction_raises():
+    with pytest.raises(Exception):
+        interactions.TrivialCrossSection(0.0, [NuMu], [Nucleon])
+    with pytest.raises(Exception):
+        interactions.TrivialCrossSection({NuMu: ([3.0, 1.0], [1e-38, 2e-38])}, [Nucleon])
+
+
+# --- end-to-end: injection with a stand-in, physical totals deferred ---
+
+
+def _make_injector(dm, standin, seed=31, n_inject=1000):
+    dists = [
+        distributions.PrimaryMass(0),
+        distributions.PowerLaw(2.0, ENERGY_MIN, ENERGY_MAX),
+        distributions.PrimaryNeutrinoHelicityDistribution(),
+        distributions.IsotropicDirection(),
+        distributions.PointSourcePositionDistribution(smath.Vector3D(0, 0, 0), 25.0),
+    ]
+    primary_inj = injection.PrimaryInjectionProcess()
+    primary_inj.primary_type = NuMu
+    primary_inj.interactions = interactions.InteractionCollection(NuMu, [standin])
+    primary_inj.distributions = dists
+
+    rand = utilities.SIREN_random(seed)
+    return injection._Injector(n_inject, dm, primary_inj, rand), dists
+
+
+def _physical_process(cross_section, dists):
+    primary_phys = injection.PhysicalProcess()
+    primary_phys.primary_type = NuMu
+    primary_phys.interactions = interactions.InteractionCollection(NuMu, [cross_section])
+    # Share the injection distribution instances so every distribution factor
+    # cancels in the weight; only the interaction factors differ between
+    # physical hypotheses.
+    primary_phys.distributions = [d for d in dists
+                                  if not isinstance(d, distributions.VertexPositionDistribution)]
+    return primary_phys
+
+
+def _generate(inj, n):
+    events = []
+    for _ in range(n):
+        try:
+            ev = inj.GenerateEvent()
+        except RuntimeError:
+            break
+        if len(ev.tree) > 0:
+            events.append(ev)
+    return events
+
+
+def test_final_state_is_pass_through(detector_model):
+    standin = _constant_cross_section()
+    inj, _ = _make_injector(detector_model, standin, seed=32)
+    events = _generate(inj, 10)
+    assert events
+    for ev in events:
+        record = ev.tree[0].record
+        assert list(record.signature.secondary_types) == [NuMu, Nucleon]
+        primary = record.primary_momentum
+        neutrino = record.secondary_momenta[0]
+        for a, b in zip(primary, neutrino):
+            assert b == pytest.approx(a, rel=1e-12, abs=1e-15)
+
+
+def test_weight_ratio_defers_total_cross_section(detector_model):
+    standin = _constant_cross_section()
+    inj, dists = _make_injector(detector_model, standin, seed=33)
+    events = _generate(inj, 25)
+    assert events
+
+    # Physical hypothesis A: the same constant total used for generation.
+    weighter_const = injection._Weighter(
+        [inj], detector_model, _physical_process(standin, dists))
+    weights_const = [weighter_const.EventWeight(ev) for ev in events]
+    assert all(pymath.isfinite(w) and w > 0.0 for w in weights_const)
+
+    # Physical hypothesis B: a tabulated (generator-provided) total.
+    weighter_table = injection._Weighter(
+        [inj], detector_model, _physical_process(_table_cross_section(), dists))
+    weights_table = [weighter_table.EventWeight(ev) for ev in events]
+    assert all(pymath.isfinite(w) and w > 0.0 for w in weights_table)
+
+    # The weights differ exactly by the ratio of physical totals at the event
+    # energy: the interaction probability is linear in the total cross section
+    # for a thin target, the normalized position density and the final-state
+    # probability are cross-section independent, and the generation side is
+    # common to both weighters.
+    for ev, w_const, w_table in zip(events, weights_const, weights_table):
+        energy = ev.tree[0].record.primary_momentum[0]
+        expected = _table_sigma(energy) / SIGMA_CONST
+        assert w_table / w_const == pytest.approx(expected, rel=1e-6)
+
+
+def test_collection_retrieval_preserves_type():
+    # The collection hands back the concrete type, so the tabulated totals
+    # remain reachable after registration in an InteractionCollection.
+    standin = _constant_cross_section()
+    collection = interactions.InteractionCollection(NuMu, [standin])
+    assert collection.HasCrossSections()
+    xs = collection.GetCrossSectionsForTarget(Nucleon)[0]
+    assert isinstance(xs, interactions.TrivialCrossSection)
+    assert xs.TotalCrossSection(NuMu, 1.0) == pytest.approx(SIGMA_CONST)


### PR DESCRIPTION
Adds a cross section for injecting neutrino interactions without committing to a final state, an interaction model, or a generation-time total: the physics content is a tabulated total cross section, which can come from an external generator and can differ between the injection and physical sides of the weight.

## TrivialCrossSection

- The final state is the primary and target unchanged (`nu + T -> nu + T`), with unit final-state probability implemented as differential over total, so the closure rule (the reported density is the sampled density) holds by construction. `DensityVariables` is empty and the base-class identity `SampleInteractionTime` is inherited, so recorded flight times pass through untouched.
- Totals are per-primary tables (energies in GeV, values in cm^2): linear interpolation between knots, zero below the first knot (which `InteractionThreshold` reports), clamped above the last. A constant-sigma constructor builds a flat two-knot table, so there are no mode flags. Both the `Nucleon` and `Ar40Nucleus` target conventions are expressible; signature enumeration filters by both primary and target.
- `equal` compares the full configuration, and the class serializes polymorphically through cereal, so archived generation configurations round-trip.

## Weighting mechanism

Injection uses any positive stand-in: with one target and one cross section per side, `CrossSectionProbability` normalizes the stand-in's scale away, the normalized position density is cross-section independent, and the interaction probability is linear in the physical total for thin targets, so the stand-in drops out of the event weight entirely. The physical total enters only through the physical process's `InteractionCollection`, supplied at weighter construction -- re-weighting a stored sample under a different generator's totals is just constructing another weighter.

Validated by seven gtest cases (interpolation, threshold and clamping, invalid construction, signature filtering, unit final-state probability, exact pass-through kinematics through `CrossSectionDistributionRecord::Finalize`, and an equality-preserving polymorphic serialization round-trip) and an end-to-end python suite against the CCM detector model, whose closure test injects with a constant stand-in and weights the same events under two physical hypotheses, asserting the per-event weight ratio equals the ratio of physical totals at the event energy to one part in a million.

At this PR's boundary: the build is green and pytest passes 865 with 23 skips; ctest matches the lineage baseline (the spline-data failures and the DensityDistribution numeric failure predate this slice).