### PR TITLE
Geometry: make polycone and sphere intersections parity-consistent at seams

### DIFF
--- a/projects/detector/private/DetectorModel.cxx
+++ b/projects/detector/private/DetectorModel.cxx
@@ -1905,13 +1905,9 @@ void DetectorModel::SectorLoop(std::function<bool(std::vector<Geometry::Intersec
                 // since this intersection does not represent a physical transition to a different sector
             }
             else {
-                // An exiting intersection for a hierarchy this walk never
-                // entered. Intersection lists cover the full line, so a
-                // missing entry can only come from a parity defect in a
-                // shape's Intersections() at a surface seam (nanometer-scale
-                // corner slivers). No integration segment is open for that
-                // sector, so the exit carries no measure: skip it instead of
-                // aborting the traversal.
+                // We have exited a hierarchy we never entered!
+                // Skip this exit intersection and warn
+                // This is likely an issue with the geometry intersection calculation
                 static std::atomic<bool> parity_warning_issued{false};
                 if(!parity_warning_issued.exchange(true)) {
                     std::cerr << "SIREN DetectorModel::SectorLoop: ignoring an exit intersection for hierarchy "

--- a/projects/detector/private/DetectorModel.cxx
+++ b/projects/detector/private/DetectorModel.cxx
@@ -1,6 +1,7 @@
 #include "SIREN/detector/DetectorModel.h"
 
 #include <mutex>
+#include <atomic>
 #include <tuple>
 #include <cmath>
 #include <cctype>
@@ -1904,9 +1905,19 @@ void DetectorModel::SectorLoop(std::function<bool(std::vector<Geometry::Intersec
                 // since this intersection does not represent a physical transition to a different sector
             }
             else {
-                // If we are exiting a sector with larger hierarchy the current_intersection should have been set to match that sector.
-                // Thus, we would not reach this point.
-                throw(std::runtime_error("Cannot exit a level that we have not entered!"));
+                // An exiting intersection for a hierarchy this walk never
+                // entered. Intersection lists cover the full line, so a
+                // missing entry can only come from a parity defect in a
+                // shape's Intersections() at a surface seam (nanometer-scale
+                // corner slivers). No integration segment is open for that
+                // sector, so the exit carries no measure: skip it instead of
+                // aborting the traversal.
+                static std::atomic<bool> parity_warning_issued{false};
+                if(!parity_warning_issued.exchange(true)) {
+                    std::cerr << "SIREN DetectorModel::SectorLoop: ignoring an exit intersection for hierarchy "
+                              << intersection->hierarchy << " with no matching entry "
+                              << "(geometry seam artifact); further occurrences are silent." << std::endl;
+                }
             }
         }
     }

--- a/projects/geometry/private/Box.cxx
+++ b/projects/geometry/private/Box.cxx
@@ -93,6 +93,12 @@ std::vector<Geometry::Intersection> Box::ComputeIntersections(siren::math::Vecto
     if(t_enter > 0 && t_enter < GEOMETRY_PRECISION) t_enter = 0;
     if(t_exit > 0 && t_exit < GEOMETRY_PRECISION) t_exit = 0;
 
+    // A pair collapsed to a single parameter (an exact corner graze, or a
+    // sub-precision sliver snapped to zero) has zero measure. Emitting it
+    // would let the model-level tie sort place the exit ahead of its entry
+    // and break enter/exit alternation downstream.
+    if(t_enter == t_exit) return {};
+
     Intersection hit_enter, hit_exit;
     hit_enter.distance = t_enter;
     hit_enter.hierarchy = 0;

--- a/projects/geometry/private/Cylinder.cxx
+++ b/projects/geometry/private/Cylinder.cxx
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <tuple>
+#include <limits>
 #include <string>
 #include <vector>
 #include <ostream>
@@ -75,6 +76,86 @@ std::vector<Geometry::Intersection> Cylinder::ComputeIntersections(siren::math::
     double r2_outer = radius_ * radius_;
     double r2_inner = inner_radius_ * inner_radius_;
 
+    // Interval (slab) method. The closed solid is
+    //     (infinite outer cylinder INTERSECT z-slab) MINUS infinite inner cylinder,
+    // so the ray-parameter set inside it is one or two disjoint intervals.
+    // Emitting each nonempty interval as an (enter, exit) pair makes the
+    // hit list parity-consistent by construction. Testing each surface
+    // independently with tolerance windows (the previous approach) let a
+    // crossing near the cap/barrel corner pass one window and fail the
+    // other, emitting an unpaired hit that broke every consumer relying
+    // on enter/exit alternation (DetectorModel::SectorLoop in particular).
+
+    double const inf = std::numeric_limits<double>::infinity();
+
+    // Ray-parameter interval inside the z-slab |z| <= hz.
+    double tz_lo, tz_hi;
+    if(dz != 0) {
+        double inv = 1.0 / dz;
+        tz_lo = (-hz - pz) * inv;
+        tz_hi = ( hz - pz) * inv;
+        if(tz_lo > tz_hi) std::swap(tz_lo, tz_hi);
+    } else {
+        if(pz < -hz || pz > hz) return {};
+        tz_lo = -inf;
+        tz_hi = inf;
+    }
+
+    // Ray-parameter interval inside the infinite outer cylinder.
+    // det = C*r2 - (px*dy - py*dx)^2 avoids catastrophic cancellation at
+    // large distances.
+    double C = dx*dx + dy*dy;
+    double B_half = px*dx + py*dy;
+    double cross_z = px * dy - py * dx;
+    double to_lo, to_hi;
+    if(C != 0) {
+        double det = C * r2_outer - cross_z * cross_z;
+        if(det <= 0) return {}; // miss, or tangent line (zero measure)
+        double sq = std::sqrt(det);
+        double inv_C = 1.0 / C;
+        to_lo = (-B_half - sq) * inv_C;
+        to_hi = (-B_half + sq) * inv_C;
+    } else {
+        if(px*px + py*py > r2_outer) return {};
+        to_lo = -inf;
+        to_hi = inf;
+    }
+
+    double a = std::max(tz_lo, to_lo);
+    double b = std::min(tz_hi, to_hi);
+    if(!(a < b)) return {};
+
+    // Subtract the bore of a hollow cylinder: up to two pieces remain.
+    double pieces[2][2];
+    int n_pieces = 0;
+    bool have_bore = false;
+    double ti_lo = 0, ti_hi = 0;
+    if(inner_radius_ > 0) {
+        if(C != 0) {
+            double det_i = C * r2_inner - cross_z * cross_z;
+            if(det_i > 0) {
+                double sq_i = std::sqrt(det_i);
+                double inv_C = 1.0 / C;
+                ti_lo = (-B_half - sq_i) * inv_C;
+                ti_hi = (-B_half + sq_i) * inv_C;
+                have_bore = true;
+            }
+        } else if(px*px + py*py < r2_inner) {
+            return {}; // axis-parallel ray inside the bore
+        }
+    }
+    if(have_bore) {
+        double lo1 = a, hi1 = std::min(b, ti_lo);
+        double lo2 = std::max(a, ti_hi), hi2 = b;
+        if(lo1 < hi1) { pieces[n_pieces][0] = lo1; pieces[n_pieces][1] = hi1; ++n_pieces; }
+        if(lo2 < hi2) { pieces[n_pieces][0] = lo2; pieces[n_pieces][1] = hi2; ++n_pieces; }
+    } else {
+        pieces[0][0] = a;
+        pieces[0][1] = b;
+        n_pieces = 1;
+    }
+    if(n_pieces == 0) return {};
+
     struct TaggedHit {
         double distance;
         siren::math::Vector3D position;
@@ -82,75 +163,27 @@ std::vector<Geometry::Intersection> Cylinder::ComputeIntersections(siren::math::
         int source; // 0 = surface, 1 = wedge
     };
 
-    TaggedHit all_hits[12]; // max: 2 barrel + 2 caps + 2 inner barrel + 2 inner caps + 2 wedge + spare
+    TaggedHit all_hits[8]; // max: 2 pieces x 2 endpoints + 2 wedge planes
     int n_all = 0;
 
-    auto add_surface_hit = [&](double t, double ix, double iy, double iz, bool entering) {
-        if(t > 0 && t < GEOMETRY_PRECISION) t = 0;
-        all_hits[n_all] = {t, siren::math::Vector3D(ix, iy, iz), entering, 0};
-        n_all++;
-    };
-
-    // Test barrel surface for a given radius squared; invert_entering flips
-    // the radial entering logic for inner surfaces
-    auto test_barrel = [&](double r2, bool invert_entering) {
-        if(dx == 0 && dy == 0) return;
-        double C = dx*dx + dy*dy;
-        double B_half = px*dx + py*dy;
-        // det = C*r2 - (px*dy - py*dx)^2
-        // avoids catastrophic cancellation at large distances
-        double cross_z = px * dy - py * dx;
-        double det = C * r2 - cross_z * cross_z;
-        if(det <= 0) return;
-        double sq = std::sqrt(det);
-        double inv_C = 1.0 / C;
-        double t1 = (-B_half - sq) * inv_C;
-        double t2 = (-B_half + sq) * inv_C;
-        for(int k = 0; k < 2; ++k) {
-            double t = (k == 0) ? t1 : t2;
-            double iz = pz + t * dz;
-            if(iz > -hz - GEOMETRY_PRECISION && iz < hz + GEOMETRY_PRECISION) {
-                double ix = px + t * dx;
-                double iy = py + t * dy;
-                bool radial_entering = (ix * dx + iy * dy) < 0;
-                add_surface_hit(t, ix, iy, iz, invert_entering ? !radial_entering : radial_entering);
-            }
-        }
-    };
-
-    // Test endcap at z_cap for a given annular ring [r2_lo, r2_hi]
-    auto test_cap = [&](double z_cap, double r2_lo, double r2_hi, bool enter) {
-        if(dz == 0) return;
-        double t = (z_cap - pz) / dz;
-        double ix = px + t * dx;
-        double iy = py + t * dy;
-        double r2_hit = ix*ix + iy*iy;
-        if(r2_hit <= r2_hi + GEOMETRY_PRECISION && r2_hit >= r2_lo - GEOMETRY_PRECISION) {
-            add_surface_hit(t, ix, iy, pz + t * dz, enter);
-        }
-    };
-
-    // Outer barrel
-    test_barrel(r2_outer, false);
-    // Endcaps (annular disk between inner and outer radius)
-    test_cap( hz, r2_inner, r2_outer, dz < 0);
-    test_cap(-hz, r2_inner, r2_outer, dz > 0);
-    // Inner barrel (if hollow)
-    if(inner_radius_ > 0) {
-        test_barrel(r2_inner, true);
+    // Emit interval endpoints, keeping the on-border convention that a
+    // boundary within GEOMETRY_PRECISION ahead of the ray origin counts as
+    // distance zero; a pair the snap collapses to zero measure is dropped.
+    for(int i = 0; i < n_pieces; ++i) {
+        double lo = pieces[i][0];
+        double hi = pieces[i][1];
+        if(lo > 0 && lo < GEOMETRY_PRECISION) lo = 0;
+        if(hi > 0 && hi < GEOMETRY_PRECISION) hi = 0;
+        if(!(lo < hi)) continue;
+        all_hits[n_all++] = {lo, siren::math::Vector3D(px + lo*dx, py + lo*dy, pz + lo*dz), true, 0};
+        all_hits[n_all++] = {hi, siren::math::Vector3D(px + hi*dx, py + hi*dy, pz + hi*dz), false, 0};
     }
+    if(n_all == 0) return {};
 
     if(!has_phi_cut_) {
-        if(n_all == 0) return {};
-        std::sort(all_hits, all_hits + n_all, [](TaggedHit const & a, TaggedHit const & b) {
-            return a.distance < b.distance;
-        });
         std::vector<Intersection> result;
         result.reserve(n_all);
         for(int i = 0; i < n_all; ++i) {
-            if(!result.empty() && std::fabs(all_hits[i].distance - result.back().distance) < GEOMETRY_PRECISION) {
-                continue;
-            }
             Intersection isect;
             isect.distance = all_hits[i].distance;
             isect.hierarchy = 0;

--- a/projects/geometry/private/Polycone.cxx
+++ b/projects/geometry/private/Polycone.cxx
@@ -2,6 +2,7 @@
 
 #include <cmath>
 #include <tuple>
+#include <limits>
 #include <string>
 #include <vector>
 #include <ostream>
@@ -15,6 +16,7 @@
 #include "SIREN/geometry/Placement.h"
 #include "GeometryMacros.h"
 #include "PhiUtils.h"
+#include "RayIntervals.h"
 
 namespace siren {
 namespace geometry {
@@ -87,14 +89,28 @@ void Polycone::print(std::ostream& os) const {
 // ------------------------------------------------------------------------- //
 // ComputeIntersections
 //
-// The polycone is decomposed into N-1 conical frustum sections between
-// adjacent z-planes. For each section, we compute ray intersections with
-// the outer cone surface, inner cone surface (if hollow), and the end caps
-// (top/bottom annular disks only for the first and last z-plane, since
-// internal z-planes are shared boundaries, not real surfaces).
+// Interval (slab) method. The polycone is the union over sections of
+//     (z-slab) INTERSECT (outer cone) MINUS (inner cone),
+// one conical frustum section per pair of adjacent z-planes. Each
+// section's in-solid ray-parameter set is a short list of disjoint
+// intervals from exact quadratic sign conditions, and the joint plane
+// ray parameters are computed once per plane index, so adjacent
+// sections share their boundary parameter bit-exactly. The union over
+// sections therefore merges seamlessly where material continues across
+// a joint and splits exactly where it does not (step joints, end caps,
+// grazes), and emitting each connected piece as an (enter, exit) pair
+// makes the hit list parity-consistent by construction. End caps and
+// internal step annuli need no dedicated surface tests: they are
+// exactly the piece boundaries that land on joint plane parameters.
 //
-// All coordinates are in local frame. Distance can be negative (full-line
-// intersections, same as Cone.cxx).
+// Testing each surface independently with tolerance windows (the
+// previous approach) let a crossing near a joint or corner circle pass
+// one window and fail another, emitting unpaired hits that broke every
+// consumer relying on enter/exit alternation
+// (DetectorModel::SectorLoop in particular).
+//
+// All coordinates are in local frame. Distance can be negative
+// (full-line intersections, same as Cone.cxx).
 // ------------------------------------------------------------------------- //
 std::vector<Geometry::Intersection> Polycone::ComputeIntersections(siren::math::Vector3D const & position, siren::math::Vector3D const & direction) const {
 
@@ -109,348 +125,155 @@ std::vector<Geometry::Intersection> Polycone::ComputeIntersections(siren::math::
     double dy = direction.GetY();
     double dz = direction.GetZ();
 
-    // Origin shift: move ray origin to closest approach to the coordinate
-    // origin. This keeps quadratic coefficients small for far-field rays,
-    // avoiding catastrophic cancellation in the discriminant B^2 - 4AC.
+    size_t n = z_planes_.size();
+
+    // Quick rejects against the z-range and the bounding cylinder keep
+    // the common miss path allocation-free.
+    if(dz == 0 && (pz < z_planes_.front() || pz >= z_planes_.back())) {
+        return {};
+    }
+    double C_xy = dx * dx + dy * dy;
+    double cross_z = px * dy - py * dx;
+    double max_r = *std::max_element(rmax_.begin(), rmax_.end());
+    if(C_xy != 0) {
+        // det = C*r^2 - (px*dy - py*dx)^2 avoids catastrophic cancellation
+        // at large distances.
+        if(C_xy * max_r * max_r - cross_z * cross_z <= 0) {
+            return {}; // miss, or tangent line (zero measure)
+        }
+    } else if(px * px + py * py > max_r * max_r) {
+        return {};
+    }
+
+    // Origin shift: quadratics are evaluated about the closest approach to
+    // the coordinate origin. This keeps their coefficients small for
+    // far-field rays, avoiding catastrophic cancellation in the
+    // discriminant B^2 - 4AC.
     double t_shift = -(px * dx + py * dy + pz * dz);
     double qx = px + t_shift * dx;
     double qy = py + t_shift * dy;
     double qz = pz + t_shift * dz;
 
-    static constexpr int STACK_CAP = 32;
-    Intersection stack_hits[STACK_CAP];
-    std::vector<Intersection> heap_hits;
-    bool using_heap = false;
-    int n_hits = 0;
+    // Ray parameter of the crossing with the z-plane of index k. Adjacent
+    // sections call this for the same k, giving bit-identical shared
+    // boundary parameters: that is what lets the piece union below merge
+    // exactly at continuous joints.
+    double inv_dz = (dz != 0) ? 1.0 / dz : 0.0;
+    auto plane_t = [&](size_t k) { return (z_planes_[k] - pz) * inv_dz; };
 
-    double intersection_x;
-    double intersection_y;
-    double intersection_z;
+    using ray_intervals::IntervalSet;
+    double const inf = std::numeric_limits<double>::infinity();
 
-    // Write a hit, promoting from stack to heap if the stack fills up.
-    auto emit = [&](double t, bool entering) {
-        Intersection isect;
-        isect.distance = t;
-        isect.hierarchy = 0;
-        isect.entering = entering;
-        isect.position = siren::math::Vector3D(intersection_x, intersection_y, intersection_z);
-        if(!using_heap) {
-            if(n_hits < STACK_CAP) {
-                stack_hits[n_hits++] = isect;
-            } else {
-                using_heap = true;
-                heap_hits.assign(stack_hits, stack_hits + STACK_CAP);
-                heap_hits.push_back(isect);
-                n_hits++;
-            }
-        } else {
-            heap_hits.push_back(isect);
-            n_hits++;
-        }
-    };
+    std::vector<std::pair<double, double>> pieces;
+    pieces.reserve(2 * (n - 1));
 
-    // Cone surface entering test using the gradient normal.
-    // For surface x^2 + y^2 = (a + b*z)^2, outward normal is (x, y, -b*(a+b*z)).
-    // Entering when normal . direction < 0.
-    auto entering_cone = [&](double a, double b) {
-        double r_val = a + b * intersection_z;
-        return (intersection_x * dx + intersection_y * dy - b * r_val * dz) < 0;
-    };
-
-    size_t n = z_planes_.size();
-
-    // Process each frustum section between adjacent z-planes
     for(size_t seg = 0; seg + 1 < n; ++seg) {
         double z_lo = z_planes_[seg];
         double z_hi = z_planes_[seg + 1];
 
-        // Skip degenerate zero-height sections
+        // Zero-height sections encode step joints; they carry no volume.
         if(z_hi <= z_lo) {
             continue;
         }
 
-        // Horizontal ray cannot hit barrel surfaces outside its z-range.
-        // Use half-open interval [z_lo, z_hi) so each boundary belongs to
-        // exactly one section and horizontal rays at internal z-planes are
-        // not skipped by both adjacent sections.
-        if(std::fabs(dz) < GEOMETRY_PRECISION && (pz < z_lo || pz >= z_hi)) {
-            continue;
+        // Ray-parameter interval inside this section's z-slab.
+        IntervalSet slab;
+        if(dz != 0) {
+            double ta = plane_t(seg);
+            double tb = plane_t(seg + 1);
+            if(ta > tb) std::swap(ta, tb);
+            slab.Add(ta, tb);
+        } else {
+            // Half-open [z_lo, z_hi): a horizontal ray at an internal
+            // plane belongs to exactly one section.
+            if(pz < z_lo || pz >= z_hi) {
+                continue;
+            }
+            slab.Add(-inf, inf);
         }
 
         double dz_sec = z_hi - z_lo;
 
-        // --- Outer conical surface for this section ---
-        {
-            double rmax_lo = rmax_[seg];
-            double rmax_hi = rmax_[seg + 1];
+        // Outer cone r_outer(z) = a + b*z: the solid needs
+        // x^2 + y^2 <= (a + b*z)^2. r_outer is non-negative throughout the
+        // slab, so the mirror nappe of the squared form lies outside it.
+        double b_outer = (rmax_[seg + 1] - rmax_[seg]) / dz_sec;
+        double a_outer = rmax_[seg] - b_outer * z_lo;
+        double r_q_outer = a_outer + b_outer * qz;
+        IntervalSet sec = ray_intervals::QuadraticLEQ(
+            C_xy - b_outer * b_outer * dz * dz,
+            qx * dx + qy * dy - b_outer * dz * r_q_outer,
+            qx * qx + qy * qy - r_q_outer * r_q_outer);
+        sec.Shift(t_shift);
+        sec = ray_intervals::Intersect(slab, sec);
 
-            // r_outer(z) = rmax_lo + (rmax_hi - rmax_lo) * (z - z_lo) / dz_sec
-            //            = a + b * z   where:
-            //   a = rmax_lo - (rmax_hi - rmax_lo) * z_lo / dz_sec
-            //   b = (rmax_hi - rmax_lo) / dz_sec
-            double b_outer = (rmax_hi - rmax_lo) / dz_sec;
-            double a_outer = rmax_lo - b_outer * z_lo;
-
-            // Surface equation: x^2 + y^2 = (a + b*z)^2
-            // Substituting ray with shifted origin (q) gives: A*s^2 + B*s + C = 0
-            // where s = t - t_shift (roots are shifted back to absolute t).
-            double A = dx * dx + dy * dy - b_outer * b_outer * dz * dz;
-            double B = 2.0 * (qx * dx + qy * dy - b_outer * dz * (a_outer + b_outer * qz));
-            double C = qx * qx + qy * qy - (a_outer + b_outer * qz) * (a_outer + b_outer * qz);
-
-            if(!(dx == 0 && dy == 0 && b_outer == 0)) {
-                double determinant = B * B - 4.0 * A * C;
-
-                if(std::fabs(A) > GEOMETRY_PRECISION) {
-                    if(determinant > 0) {
-                        double sqrt_det = std::sqrt(determinant);
-                        double t1 = (-B + sqrt_det) / (2.0 * A) + t_shift;
-                        double t2 = (-B - sqrt_det) / (2.0 * A) + t_shift;
-
-                        if(t1 > 0 && t1 < GEOMETRY_PRECISION)
-                            t1 = 0;
-                        if(t2 > 0 && t2 < GEOMETRY_PRECISION)
-                            t2 = 0;
-
-                        intersection_z = pz + t1 * dz;
-                        if(intersection_z >= z_lo && intersection_z < z_hi) {
-                            intersection_x = px + t1 * dx;
-                            intersection_y = py + t1 * dy;
-                            double r_at_z = a_outer + b_outer * intersection_z;
-                            if(r_at_z >= 0) {
-                                bool entering = entering_cone(a_outer, b_outer);
-                                emit(t1, entering);
-                            }
-                        }
-
-                        intersection_z = pz + t2 * dz;
-                        if(intersection_z >= z_lo && intersection_z < z_hi) {
-                            intersection_x = px + t2 * dx;
-                            intersection_y = py + t2 * dy;
-                            double r_at_z = a_outer + b_outer * intersection_z;
-                            if(r_at_z >= 0) {
-                                bool entering = entering_cone(a_outer, b_outer);
-                                emit(t2, entering);
-                            }
-                        }
-                    }
-                } else if(std::fabs(B) > GEOMETRY_PRECISION) {
-                    // Linear case: ray parallel to cone surface
-                    double t1 = -C / B + t_shift;
-                    if(t1 > 0 && t1 < GEOMETRY_PRECISION)
-                        t1 = 0;
-
-                    intersection_z = pz + t1 * dz;
-                    if(intersection_z >= z_lo && intersection_z < z_hi) {
-                        intersection_x = px + t1 * dx;
-                        intersection_y = py + t1 * dy;
-                        double r_at_z = a_outer + b_outer * intersection_z;
-                        if(r_at_z >= 0) {
-                            bool entering = entering_cone(a_outer, b_outer);
-                            emit(t1, entering);
-                        }
-                    }
-                }
-            }
+        // Inner cone (hollow sections): subtract the bore.
+        if(sec.n > 0 && (rmin_[seg] > 0 || rmin_[seg + 1] > 0)) {
+            double b_inner = (rmin_[seg + 1] - rmin_[seg]) / dz_sec;
+            double a_inner = rmin_[seg] - b_inner * z_lo;
+            double r_q_inner = a_inner + b_inner * qz;
+            IntervalSet bore = ray_intervals::QuadraticLEQ(
+                C_xy - b_inner * b_inner * dz * dz,
+                qx * dx + qy * dy - b_inner * dz * r_q_inner,
+                qx * qx + qy * qy - r_q_inner * r_q_inner);
+            bore.Shift(t_shift);
+            sec = ray_intervals::Subtract(sec, bore);
         }
 
-        // --- Inner conical surface for this section (hollow) ---
-        if(rmin_[seg] > 0 || rmin_[seg + 1] > 0) {
-            double rmin_lo = rmin_[seg];
-            double rmin_hi = rmin_[seg + 1];
-
-            double b_inner = (rmin_hi - rmin_lo) / dz_sec;
-            double a_inner = rmin_lo - b_inner * z_lo;
-
-            double A = dx * dx + dy * dy - b_inner * b_inner * dz * dz;
-            double B = 2.0 * (qx * dx + qy * dy - b_inner * dz * (a_inner + b_inner * qz));
-            double C = qx * qx + qy * qy - (a_inner + b_inner * qz) * (a_inner + b_inner * qz);
-
-            if(!(dx == 0 && dy == 0 && b_inner == 0)) {
-                double determinant = B * B - 4.0 * A * C;
-
-                if(std::fabs(A) > GEOMETRY_PRECISION) {
-                    if(determinant > 0) {
-                        double sqrt_det = std::sqrt(determinant);
-                        double t1 = (-B + sqrt_det) / (2.0 * A) + t_shift;
-                        double t2 = (-B - sqrt_det) / (2.0 * A) + t_shift;
-
-                        if(t1 > 0 && t1 < GEOMETRY_PRECISION)
-                            t1 = 0;
-                        if(t2 > 0 && t2 < GEOMETRY_PRECISION)
-                            t2 = 0;
-
-                        intersection_z = pz + t1 * dz;
-                        if(intersection_z >= z_lo && intersection_z < z_hi) {
-                            intersection_x = px + t1 * dx;
-                            intersection_y = py + t1 * dy;
-                            double r_at_z = a_inner + b_inner * intersection_z;
-                            if(r_at_z >= 0) {
-                                bool entering = !entering_cone(a_inner, b_inner);
-                                emit(t1, entering);
-                            }
-                        }
-
-                        intersection_z = pz + t2 * dz;
-                        if(intersection_z >= z_lo && intersection_z < z_hi) {
-                            intersection_x = px + t2 * dx;
-                            intersection_y = py + t2 * dy;
-                            double r_at_z = a_inner + b_inner * intersection_z;
-                            if(r_at_z >= 0) {
-                                bool entering = !entering_cone(a_inner, b_inner);
-                                emit(t2, entering);
-                            }
-                        }
-                    }
-                } else if(std::fabs(B) > GEOMETRY_PRECISION) {
-                    double t1 = -C / B + t_shift;
-                    if(t1 > 0 && t1 < GEOMETRY_PRECISION)
-                        t1 = 0;
-
-                    intersection_z = pz + t1 * dz;
-                    if(intersection_z >= z_lo && intersection_z < z_hi) {
-                        intersection_x = px + t1 * dx;
-                        intersection_y = py + t1 * dy;
-                        double r_at_z = a_inner + b_inner * intersection_z;
-                        if(r_at_z >= 0) {
-                            bool entering = !entering_cone(a_inner, b_inner);
-                            emit(t1, entering);
-                        }
-                    }
-                }
-            }
+        for(int i = 0; i < sec.n; ++i) {
+            pieces.emplace_back(sec.lo[i], sec.hi[i]);
         }
     }
 
-    // --- End caps: bottom (z_planes_[0]) and top (z_planes_[n-1]) ---
-    if(std::fabs(dz) > GEOMETRY_PRECISION) {
-        // Bottom cap
-        {
-            double z_cap = z_planes_.front();
-            double t = (z_cap - pz) / dz;
-
-            if(t > 0 && t < GEOMETRY_PRECISION)
-                t = 0;
-
-            intersection_x = px + t * dx;
-            intersection_y = py + t * dy;
-
-            double r2_hit = intersection_x * intersection_x + intersection_y * intersection_y;
-            double rmax_cap = rmax_.front();
-            double rmin_cap = rmin_.front();
-            double rmax2 = rmax_cap * rmax_cap;
-            double rmin2 = rmin_cap * rmin_cap;
-            double r2_tol = GEOMETRY_PRECISION * std::fmax(1.0, rmax2);
-            if(r2_hit <= rmax2 + r2_tol && r2_hit >= rmin2 - r2_tol) {
-                intersection_z = pz + t * dz;
-                emit(t, dz > 0);
-            }
-        }
-
-        // Top cap
-        {
-            double z_cap = z_planes_.back();
-            double t = (z_cap - pz) / dz;
-
-            if(t > 0 && t < GEOMETRY_PRECISION)
-                t = 0;
-
-            intersection_x = px + t * dx;
-            intersection_y = py + t * dy;
-
-            double r2_hit = intersection_x * intersection_x + intersection_y * intersection_y;
-            double rmax_cap = rmax_.back();
-            double rmin_cap = rmin_.back();
-            double rmax2 = rmax_cap * rmax_cap;
-            double rmin2 = rmin_cap * rmin_cap;
-            double r2_tol = GEOMETRY_PRECISION * std::fmax(1.0, rmax2);
-            if(r2_hit <= rmax2 + r2_tol && r2_hit >= rmin2 - r2_tol) {
-                intersection_z = pz + t * dz;
-                emit(t, dz < 0);
-            }
-        }
+    if(pieces.empty()) {
+        return {};
     }
 
-    // --- Internal caps for step changes in radius ---
-    // These arise at z-planes where consecutive entries share the same z
-    // but have different radii (step discontinuity). We group consecutive
-    // z-planes at the same z-value and compare radii across the group.
-    if(std::fabs(dz) > GEOMETRY_PRECISION) {
-        size_t i = 1; // skip first z-plane (endcap handles it)
-        while(i + 1 < n) { // skip last z-plane
-            double z_here = z_planes_[i];
+    // Sections were visited in ascending z; for dz < 0 the ray traverses
+    // them in descending parameter order.
+    std::sort(pieces.begin(), pieces.end());
 
-            // Find the extent of z-planes at the same z
-            size_t j = i;
-            while(j + 1 < n - 1 && z_planes_[j + 1] == z_here) {
-                j++;
-            }
-
-            // Radii at the top of the section below this group = values at index i
-            // Radii at the bottom of the section above this group = values at index j
-            double rmin_below = rmin_[i];
-            double rmax_below = rmax_[i];
-            double rmin_above = rmin_[j];
-            double rmax_above = rmax_[j];
-
-            if(rmax_below == rmax_above && rmin_below == rmin_above) {
-                i = j + 1;
-                continue;
-            }
-
-            double t = (z_here - pz) / dz;
-
-            if(t > 0 && t < GEOMETRY_PRECISION)
-                t = 0;
-
-            intersection_x = px + t * dx;
-            intersection_y = py + t * dy;
-            intersection_z = pz + t * dz;
-
-            double r2_hit = intersection_x * intersection_x + intersection_y * intersection_y;
-
-            // Outer annulus: region where rmax changed
-            if(rmax_below != rmax_above) {
-                double rlo = std::min(rmax_below, rmax_above);
-                double rhi = std::max(rmax_below, rmax_above);
-                if(r2_hit >= rlo * rlo && r2_hit <= rhi * rhi) {
-                    // Material exists on the side with larger rmax
-                    // entering = moving into material
-                    bool entering = (rmax_above > rmax_below) ? (dz > 0) : (dz < 0);
-                    emit(t, entering);
-                }
-            }
-
-            // Inner annulus: region where rmin changed
-            if(rmin_below != rmin_above) {
-                double rlo = std::min(rmin_below, rmin_above);
-                double rhi = std::max(rmin_below, rmin_above);
-                if(r2_hit >= rlo * rlo && r2_hit <= rhi * rhi) {
-                    // Hole grows on the side with larger rmin,
-                    // so material exists on the side with smaller rmin
-                    bool entering = (rmin_above > rmin_below) ? (dz < 0) : (dz > 0);
-                    emit(t, entering);
-                }
-            }
-
-            i = j + 1;
+    // Snap piece boundaries within GEOMETRY_PRECISION ahead of the ray
+    // origin to distance zero (the on-border convention), drop pieces the
+    // snap collapses, and merge pieces that touch or overlap: continuous
+    // joints share their plane parameter bit-exactly and coalesce here,
+    // so only real material boundaries survive as (enter, exit) pairs.
+    std::vector<std::pair<double, double>> solid;
+    solid.reserve(pieces.size());
+    for(auto const & piece : pieces) {
+        double lo = piece.first;
+        double hi = piece.second;
+        if(lo > 0 && lo < GEOMETRY_PRECISION) lo = 0;
+        if(hi > 0 && hi < GEOMETRY_PRECISION) hi = 0;
+        if(!(lo < hi)) continue;
+        if(!solid.empty() && lo <= solid.back().second) {
+            if(hi > solid.back().second) solid.back().second = hi;
+            continue;
         }
+        solid.emplace_back(lo, hi);
+    }
+    if(solid.empty()) {
+        return {};
     }
 
-    if(n_hits == 0) return {};
-
-    auto cmp = [](Intersection const & a, Intersection const & b) {
-        return a.distance < b.distance;
+    auto make_hit = [&](double t, bool entering) {
+        Intersection isect;
+        isect.distance = t;
+        isect.hierarchy = 0;
+        isect.entering = entering;
+        isect.position = siren::math::Vector3D(px + t * dx, py + t * dy, pz + t * dz);
+        return isect;
     };
 
     if(!has_phi_cut_) {
-        // No phi cut: surface hits are the final result
-        if(using_heap) {
-            std::sort(heap_hits.begin(), heap_hits.end(), cmp);
-            return heap_hits;
+        // No phi cut: the interval endpoints are the final result
+        std::vector<Intersection> result;
+        result.reserve(2 * solid.size());
+        for(auto const & piece : solid) {
+            result.push_back(make_hit(piece.first, true));
+            result.push_back(make_hit(piece.second, false));
         }
-        std::sort(stack_hits, stack_hits + n_hits, cmp);
-        return {stack_hits, stack_hits + n_hits};
+        return result;
     }
 
     // Phi cut: merge surface hits with infinite wedge hits and run CSG walk.
@@ -458,7 +281,6 @@ std::vector<Geometry::Intersection> Polycone::ComputeIntersections(siren::math::
     // wedge (two half-planes from the z-axis). A sorted walk over both hit
     // lists produces the CSG intersection. This pattern is duplicated across
     // Polycone, GenericPolycone, Sphere, Torus, Cylinder, Cone, CutTube.
-    // Collect surface hits into a sorted vector of tagged hits.
     struct TaggedHit {
         double distance;
         siren::math::Vector3D position;
@@ -466,18 +288,13 @@ std::vector<Geometry::Intersection> Polycone::ComputeIntersections(siren::math::
         int source; // 0 = surface, 1 = wedge
     };
 
-    // Sort surface hits first
-    if(using_heap) {
-        std::sort(heap_hits.begin(), heap_hits.end(), cmp);
-    } else {
-        std::sort(stack_hits, stack_hits + n_hits, cmp);
-    }
-
     std::vector<TaggedHit> all_hits;
-    all_hits.reserve(n_hits + 2);
-    for(int i = 0; i < n_hits; ++i) {
-        Intersection const & h = using_heap ? heap_hits[i] : stack_hits[i];
-        all_hits.push_back({h.distance, h.position, h.entering, 0});
+    all_hits.reserve(2 * solid.size() + 2);
+    for(auto const & piece : solid) {
+        for(int k = 0; k < 2; ++k) {
+            double t = (k == 0) ? piece.first : piece.second;
+            all_hits.push_back({t, siren::math::Vector3D(px + t * dx, py + t * dy, pz + t * dz), k == 0, 0});
+        }
     }
 
     // Compute infinite wedge intersections (two half-planes from z-axis)

--- a/projects/geometry/private/RayIntervals.h
+++ b/projects/geometry/private/RayIntervals.h
@@ -1,0 +1,177 @@
+// Interval-set algebra along a ray parameter, shared by the solid-path hit
+// generation of shapes assembled from quadric sign conditions (Polycone,
+// Sphere). The in-solid ray-parameter set of such a shape is built here
+// from closed quadratic and half-line conditions with exact set operations;
+// emitting each connected piece of the final set as an (enter, exit) pair
+// makes the hit list parity-consistent by construction, with no per-surface
+// tolerance windows that can disagree at surface seams (the failure mode
+// fixed for Cylinder by the same interval method, done inline there).
+
+#pragma once
+#ifndef SIREN_RayIntervals_H
+#define SIREN_RayIntervals_H
+
+#include <cmath>
+#include <limits>
+#include <cassert>
+#include <algorithm>
+
+namespace siren {
+namespace geometry {
+namespace ray_intervals {
+
+// A set of disjoint closed intervals [lo, hi] with lo < hi, sorted by lo.
+// Endpoints may be +-infinity. Every operation below preserves the
+// invariant. CAP is far above what the algebra in this codebase can
+// produce (each constraint contributes at most two pieces and only a
+// handful of constraints are combined per solid); if it were ever hit,
+// whole pieces would be dropped, which loses a sliver of volume but can
+// never break enter/exit pairing.
+struct IntervalSet {
+    static constexpr int CAP = 8;
+    double lo[CAP];
+    double hi[CAP];
+    int n = 0;
+
+    // Append a piece; the caller is responsible for keeping the sorted,
+    // disjoint invariant. Empty and inverted pieces are dropped (the
+    // comparison also rejects NaN endpoints).
+    void Add(double a, double b) {
+        if(!(a < b)) return;
+        assert(n < CAP);
+        if(n >= CAP) return;
+        lo[n] = a;
+        hi[n] = b;
+        ++n;
+    }
+
+    void Shift(double dt) {
+        for(int i = 0; i < n; ++i) {
+            lo[i] += dt;
+            hi[i] += dt;
+        }
+    }
+
+    static IntervalSet Full() {
+        IntervalSet s;
+        double const inf = std::numeric_limits<double>::infinity();
+        s.Add(-inf, inf);
+        return s;
+    }
+};
+
+// Intersection of two sets: two-pointer sweep over the sorted piece lists.
+inline IntervalSet Intersect(IntervalSet const & A, IntervalSet const & B) {
+    IntervalSet out;
+    int i = 0, j = 0;
+    while(i < A.n && j < B.n) {
+        out.Add(std::max(A.lo[i], B.lo[j]), std::min(A.hi[i], B.hi[j]));
+        if(A.hi[i] < B.hi[j]) ++i;
+        else ++j;
+    }
+    return out;
+}
+
+// Union of two sets: merge-sweep; pieces that overlap or touch exactly
+// (shared endpoint, bit-identical) coalesce into one.
+inline IntervalSet Union(IntervalSet const & A, IntervalSet const & B) {
+    IntervalSet out;
+    int i = 0, j = 0;
+    double cur_lo = 0, cur_hi = 0;
+    bool open = false;
+    while(i < A.n || j < B.n) {
+        double a, b;
+        if(j >= B.n || (i < A.n && A.lo[i] <= B.lo[j])) {
+            a = A.lo[i]; b = A.hi[i]; ++i;
+        } else {
+            a = B.lo[j]; b = B.hi[j]; ++j;
+        }
+        if(!open) {
+            cur_lo = a; cur_hi = b; open = true;
+        } else if(a <= cur_hi) {
+            cur_hi = std::max(cur_hi, b);
+        } else {
+            out.Add(cur_lo, cur_hi);
+            cur_lo = a; cur_hi = b;
+        }
+    }
+    if(open) out.Add(cur_lo, cur_hi);
+    return out;
+}
+
+// A minus B. Remnant pieces keep the boundary parameters of B (closed
+// remnants), so a hit landing on a subtracted surface stays on it.
+inline IntervalSet Subtract(IntervalSet const & A, IntervalSet const & B) {
+    IntervalSet out;
+    for(int i = 0; i < A.n; ++i) {
+        double cursor = A.lo[i];
+        double end = A.hi[i];
+        for(int j = 0; j < B.n && cursor < end; ++j) {
+            if(B.hi[j] <= cursor) continue;
+            if(B.lo[j] >= end) break;
+            out.Add(cursor, std::min(end, B.lo[j]));
+            cursor = std::max(cursor, B.hi[j]);
+        }
+        out.Add(cursor, end);
+    }
+    return out;
+}
+
+// The closed set {t : A*t^2 + 2*B_half*t + C <= 0}. Zero-measure solutions
+// (tangencies) come out empty, matching the tangent-line-is-a-miss policy
+// of the interval method. Roots use the numerically stable split (one root
+// from the large-magnitude numerator, the other from C over it), so a tiny
+// leading coefficient degrades gracefully toward the linear case instead
+// of amplifying cancellation; an overflowed root becomes an infinite
+// endpoint, which is the correct limit.
+inline IntervalSet QuadraticLEQ(double A, double B_half, double C) {
+    IntervalSet out;
+    double const inf = std::numeric_limits<double>::infinity();
+    if(A == 0) {
+        if(B_half > 0) out.Add(-inf, -C / (2.0 * B_half));
+        else if(B_half < 0) out.Add(-C / (2.0 * B_half), inf);
+        else if(C <= 0) out.Add(-inf, inf);
+        return out;
+    }
+    double det = B_half * B_half - A * C;
+    if(det <= 0) {
+        // No sign change: the parabola stays on one side (touching zero at
+        // most at a point). Below the axis everywhere iff it opens down.
+        if(A < 0) out.Add(-inf, inf);
+        return out;
+    }
+    double sq = std::sqrt(det);
+    double q = -(B_half + std::copysign(sq, B_half));
+    double t1 = q / A;
+    double t2 = C / q;
+    if(t1 > t2) std::swap(t1, t2);
+    if(A > 0) {
+        out.Add(t1, t2);
+    } else {
+        out.Add(-inf, t1);
+        out.Add(t2, inf);
+    }
+    return out;
+}
+
+inline IntervalSet QuadraticGEQ(double A, double B_half, double C) {
+    return QuadraticLEQ(-A, -B_half, -C);
+}
+
+// The closed set {t : pz + t*dz >= 0}. The complement's boundary parameter
+// is bit-identical (negate both arguments), so unions of the two half-lines
+// coalesce exactly at the plane crossing.
+inline IntervalSet HalfLineGEQ(double pz, double dz) {
+    IntervalSet out;
+    double const inf = std::numeric_limits<double>::infinity();
+    if(dz > 0) out.Add(-pz / dz, inf);
+    else if(dz < 0) out.Add(-inf, -pz / dz);
+    else if(pz >= 0) out.Add(-inf, inf);
+    return out;
+}
+
+} // namespace ray_intervals
+} // namespace geometry
+} // namespace siren
+
+#endif // SIREN_RayIntervals_H

--- a/projects/geometry/private/Sphere.cxx
+++ b/projects/geometry/private/Sphere.cxx
@@ -17,28 +17,14 @@
 #include "SIREN/geometry/Placement.h"
 #include "GeometryMacros.h"
 #include "PhiUtils.h"
+#include "RayIntervals.h"
 
 namespace siren {
 namespace geometry {
 
 namespace {
-using phi_utils::NormalizePhi;
-using phi_utils::PhiInRange;
 using phi_utils::InitialPhiState;
 using phi_utils::ZAxisWedgeEntering;
-using phi_utils::TWO_PI;
-
-// Check if the polar angle of point (x,y,z) falls within
-// [start_theta, start_theta + delta_theta].
-bool ThetaInRange(double x, double y, double z, double start_theta, double delta_theta) {
-    double r = std::sqrt(x*x + y*y + z*z);
-    if(r < 1e-15) return true; // origin is degenerate
-    double cos_theta = z / r;
-    if(cos_theta > 1.0) cos_theta = 1.0;
-    if(cos_theta < -1.0) cos_theta = -1.0;
-    double theta = std::acos(cos_theta);
-    return theta >= start_theta - 1e-9 && theta <= start_theta + delta_theta + 1e-9;
-}
 } // anonymous namespace
 
 Sphere::Sphere() : Geometry("Sphere"), radius_(0), inner_radius_(0), start_phi_(0), delta_phi_(2.0 * M_PI), start_theta_(0), delta_theta_(M_PI), has_phi_cut_(false), has_theta_cut_(false) { RecomputeWorldAABB(); }
@@ -93,152 +79,144 @@ std::vector<Geometry::Intersection> Sphere::ComputeIntersections(
 
     double px = position.GetX(), py = position.GetY(), pz = position.GetZ();
     double dx = direction.GetX(), dy = direction.GetY(), dz = direction.GetZ();
-    double pp = px*px + py*py + pz*pz;
     double pd = px*dx + py*dy + pz*dz;
+    double dd = dx*dx + dy*dy + dz*dz;
+    if(dd == 0) return {};
 
-    // The sphere with angular cuts is treated as:
-    //   (spherical shell) AND (phi wedge) AND (theta band)
-    // Each component produces independent enter/exit pairs. A CSG intersection
-    // walk combines them without tolerance-dependent filtering or heuristics.
-    // Source tags: 0 = shell, 1 = phi wedge, 2 = theta band
-    struct TaggedHit {
-        double distance;
-        siren::math::Vector3D position;
-        bool entering;
-        int source;
-    };
+    // Interval (slab) method. The solid is
+    //     (ball MINUS inner ball) INTERSECT (theta band) INTERSECT (phi wedge).
+    // The first two factors are solids of revolution about z, so their
+    // in-solid ray-parameter sets are short lists of disjoint intervals
+    // computed with exact set algebra; emitting each connected piece of
+    // their intersection as an (enter, exit) pair makes the surface hit
+    // list parity-consistent by construction. Only the phi wedge remains
+    // a CSG state walk, consuming the interval endpoints as surface hits
+    // (same pattern as Cylinder and Polycone). The previous per-root
+    // theta-cone tests filtered each root through tolerance windows
+    // (nappe sign, apex proximity) with sign-derived entering flags,
+    // which could emit inconsistent band sequences at the cone/sphere
+    // seam circles and silently corrupt the state walk.
 
-    TaggedHit all_hits[16]; // max: 4 shell + 4 phi planes + 8 theta cones
-    int n_all = 0;
+    using ray_intervals::IntervalSet;
 
-    auto add_hit = [&](double t, bool entering, int source) {
-        if(t > 0 && t < GEOMETRY_PRECISION) t = 0;
-        all_hits[n_all] = {t, siren::math::Vector3D(px + t*dx, py + t*dy, pz + t*dz), entering, source};
-        n_all++;
-    };
-
-    // ---- Shell intersections (no angular filtering) ----
-    // The discriminant is r^2 - |p x d|^2 (squared perpendicular distance
-    // from origin to ray). Computing |p x d|^2 directly avoids catastrophic
-    // cancellation that occurs when the ray origin is far from the sphere.
+    // ---- Radial shell: {|x| <= radius} minus the inner ball ----
+    // det = dd*r^2 - |p x d|^2 (squared perpendicular distance from the
+    // origin to the ray, times dd). Computing |p x d|^2 directly avoids
+    // catastrophic cancellation when the ray origin is far from the sphere.
     double cx = py * dz - pz * dy;
     double cy = pz * dx - px * dz;
     double cz = px * dy - py * dx;
     double perp2 = cx*cx + cy*cy + cz*cz;
-    auto solve_shell = [&](double r, bool is_outer) {
-        double det = r * r - perp2;
-        if(det <= 0) return;
-        double sq = std::sqrt(det);
-        double t1 = -pd - sq;
-        double t2 = -pd + sq;
-        for(int k = 0; k < 2; ++k) {
-            double t = (k == 0) ? t1 : t2;
-            bool entering = is_outer ? (k == 0) : (k == 1);
-            add_hit(t, entering, 0);
+    double inv_dd = 1.0 / dd;
+    double det_o = dd * radius_ * radius_ - perp2;
+    if(det_o <= 0) return {}; // miss, or tangent line (zero measure)
+    double sq_o = std::sqrt(det_o);
+    IntervalSet solid;
+    solid.Add((-pd - sq_o) * inv_dd, (-pd + sq_o) * inv_dd);
+    if(inner_radius_ > 0) {
+        double det_i = dd * inner_radius_ * inner_radius_ - perp2;
+        if(det_i > 0) {
+            double sq_i = std::sqrt(det_i);
+            IntervalSet bore;
+            bore.Add((-pd - sq_i) * inv_dd, (-pd + sq_i) * inv_dd);
+            solid = ray_intervals::Subtract(solid, bore);
         }
+    }
+
+    // ---- Theta band: {start_theta <= theta(x(t)) <= start_theta + delta} ----
+    // theta(x) <= theta0 is z >= cos(theta0)*|x|, split into the exact
+    // z-halfspace and the sign set of the quadratic z^2 - c^2*|x|^2 (the
+    // squared form covers both cone nappes; the halfspace picks the right
+    // one). The {z >= 0} and {z <= 0} sets share their boundary parameter
+    // bit-exactly, so unions across the equator plane coalesce exactly.
+    if(has_theta_cut_ && solid.n > 0) {
+        IntervalSet const h_pos = ray_intervals::HalfLineGEQ(pz, dz);   // {z(t) >= 0}
+        IntervalSet const h_neg = ray_intervals::HalfLineGEQ(-pz, -dz); // {z(t) <= 0}
+
+        // Cone quadrics are evaluated about the ray's closest approach to
+        // the apex: there the squared apex distance is exactly perp2/dd
+        // (free of cancellation) and the linear coefficient collapses,
+        // conditioning far-origin rays.
+        double t_ca = -pd * inv_dd;
+        double qz_ca = pz + t_ca * dz;
+        double qd_ca = pd + t_ca * dd; // ~0; kept so the shifted polynomial is exact
+        double qq_ca = perp2 * inv_dd;
+        auto cone_quadric = [&](double c2, bool geq) {
+            double A = dz*dz - c2 * dd;
+            double B_half = qz_ca * dz - c2 * qd_ca;
+            double C = qz_ca * qz_ca - c2 * qq_ca;
+            IntervalSet s = geq ? ray_intervals::QuadraticGEQ(A, B_half, C)
+                                : ray_intervals::QuadraticLEQ(A, B_half, C);
+            s.Shift(t_ca);
+            return s;
+        };
+
+        // {theta(x(t)) <= theta0}, i.e. {z >= cos(theta0)*|x|}
+        auto theta_below = [&](double theta0) {
+            if(std::fabs(theta0 - M_PI / 2.0) < 1e-12) return h_pos;
+            double c = std::cos(theta0);
+            if(c > 0) return ray_intervals::Intersect(h_pos, cone_quadric(c*c, true));
+            return ray_intervals::Union(h_pos,
+                ray_intervals::Intersect(h_neg, cone_quadric(c*c, false)));
+        };
+        // {theta(x(t)) >= theta0}, i.e. {z <= cos(theta0)*|x|}
+        auto theta_above = [&](double theta0) {
+            if(std::fabs(theta0 - M_PI / 2.0) < 1e-12) return h_neg;
+            double c = std::cos(theta0);
+            if(c < 0) return ray_intervals::Intersect(h_neg, cone_quadric(c*c, true));
+            return ray_intervals::Union(h_neg,
+                ray_intervals::Intersect(h_pos, cone_quadric(c*c, false)));
+        };
+
+        double theta_max = start_theta_ + delta_theta_;
+        if(theta_max < M_PI - 1e-12)
+            solid = ray_intervals::Intersect(solid, theta_below(theta_max));
+        if(start_theta_ > 1e-12 && solid.n > 0)
+            solid = ray_intervals::Intersect(solid, theta_above(start_theta_));
+    }
+    if(solid.n == 0) return {};
+
+    struct TaggedHit {
+        double distance;
+        siren::math::Vector3D position;
+        bool entering;
+        int source; // 0 = surface, 1 = wedge
     };
 
-    solve_shell(radius_, true);
-    if(inner_radius_ > 0) {
-        solve_shell(inner_radius_, false);
-    }
+    TaggedHit all_hits[2 * IntervalSet::CAP + 2];
+    int n_all = 0;
 
-    // ---- Infinite phi wedge (no radial/theta bounds) ----
-    if(has_phi_cut_) {
-        bool z_axis_hit_emitted = false;
-        for(int face = 0; face < 2; ++face) {
-            double alpha = start_phi_ + face * delta_phi_;
-            double ca = std::cos(alpha), sa = std::sin(alpha);
-            double nx, ny;
-            if(face == 0) { nx = sa; ny = -ca; }
-            else { nx = -sa; ny = ca; }
-            double n_dot_d = nx*dx + ny*dy;
-            if(std::fabs(n_dot_d) < GEOMETRY_PRECISION) continue;
-            double n_dot_p = nx*px + ny*py;
-            double t = -n_dot_p / n_dot_d;
-            double hx = px + t*dx, hy = py + t*dy;
-            if(hx*ca + hy*sa < -GEOMETRY_PRECISION) continue;
-            bool entering = (n_dot_d < 0);
-            if(hx*hx + hy*hy < GEOMETRY_PRECISION * 1e3 * GEOMETRY_PRECISION * 1e3) {
-                if(z_axis_hit_emitted) continue;
-                z_axis_hit_emitted = true;
-                entering = ZAxisWedgeEntering(dx, dy, start_phi_, delta_phi_);
-            }
-            add_hit(t, entering, 1);
-        }
-    }
-
-    // ---- Infinite theta band boundaries (no radial/phi bounds) ----
-    if(has_theta_cut_) {
-        bool theta_apex_emitted = false;
-        for(int face = 0; face < 2; ++face) {
-            double theta0 = start_theta_ + face * delta_theta_;
-            if(theta0 < 1e-12 || std::fabs(theta0 - M_PI) < 1e-12) continue;
-
-            if(std::fabs(theta0 - M_PI / 2.0) < 1e-12) {
-                if(std::fabs(dz) < GEOMETRY_PRECISION) continue;
-                double t = -pz / dz;
-                bool entering = (face == 0) ? (dz < 0) : (dz > 0);
-                add_hit(t, entering, 2);
+    // Emit interval endpoints, keeping the on-border convention that a
+    // boundary within GEOMETRY_PRECISION ahead of the ray origin counts as
+    // distance zero; a piece the snap collapses is dropped and pieces it
+    // makes touch are merged, so no zero-measure pair is ever emitted.
+    {
+        double merged_lo = 0, merged_hi = 0;
+        bool have_piece = false;
+        auto emit_piece = [&](double lo, double hi) {
+            all_hits[n_all++] = {lo, siren::math::Vector3D(px + lo*dx, py + lo*dy, pz + lo*dz), true, 0};
+            all_hits[n_all++] = {hi, siren::math::Vector3D(px + hi*dx, py + hi*dy, pz + hi*dz), false, 0};
+        };
+        for(int i = 0; i < solid.n; ++i) {
+            double lo = solid.lo[i];
+            double hi = solid.hi[i];
+            if(lo > 0 && lo < GEOMETRY_PRECISION) lo = 0;
+            if(hi > 0 && hi < GEOMETRY_PRECISION) hi = 0;
+            if(!(lo < hi)) continue;
+            if(have_piece && lo <= merged_hi) {
+                if(hi > merged_hi) merged_hi = hi;
                 continue;
             }
-
-            double tan_t = std::tan(theta0);
-            double tan2 = tan_t * tan_t;
-            double A = dx*dx + dy*dy - dz*dz * tan2;
-            double B_half = px*dx + py*dy - pz*dz * tan2;
-            double C = px*px + py*py - pz*pz * tan2;
-
-            double det = B_half * B_half - A * C;
-            if(det < 0) continue;
-            double sq = std::sqrt(std::fmax(det, 0.0));
-
-            for(int root = 0; root < 2; ++root) {
-                double t;
-                if(std::fabs(A) > GEOMETRY_PRECISION) {
-                    t = (root == 0) ? (-B_half - sq) / A : (-B_half + sq) / A;
-                } else if(root == 0 && std::fabs(B_half) > GEOMETRY_PRECISION) {
-                    t = -C / (2.0 * B_half);
-                } else {
-                    continue;
-                }
-
-                double hx = px + t*dx, hy = py + t*dy, hz = pz + t*dz;
-                if(theta0 < M_PI / 2.0 && hz < -GEOMETRY_PRECISION) continue;
-                if(theta0 > M_PI / 2.0 && hz > GEOMETRY_PRECISION) continue;
-
-                double h2 = hx*hx + hy*hy + hz*hz;
-                if(h2 < GEOMETRY_PRECISION * 1e3 * GEOMETRY_PRECISION * 1e3) {
-                    if(theta_apex_emitted) continue;
-                    theta_apex_emitted = true;
-                    double eps = GEOMETRY_PRECISION * 1e3;
-                    bool entering = ThetaInRange(hx + eps*dx, hy + eps*dy, hz + eps*dz,
-                                                 start_theta_, delta_theta_);
-                    add_hit(t, entering, 2);
-                    continue;
-                }
-
-                double gnx = hx, gny = hy, gnz = -hz * tan2;
-                double g_dot_d = gnx*dx + gny*dy + gnz*dz;
-                if(theta0 > M_PI / 2.0) g_dot_d = -g_dot_d;
-                bool entering;
-                if(face == 0) {
-                    entering = (g_dot_d > 0);
-                } else {
-                    entering = (g_dot_d < 0);
-                }
-                add_hit(t, entering, 2);
-            }
+            if(have_piece) emit_piece(merged_lo, merged_hi);
+            merged_lo = lo;
+            merged_hi = hi;
+            have_piece = true;
         }
+        if(have_piece) emit_piece(merged_lo, merged_hi);
     }
-
     if(n_all == 0) return {};
 
-    // No angular cuts: shell hits are the final result
-    if(!has_phi_cut_ && !has_theta_cut_) {
-        std::sort(all_hits, all_hits + n_all, [](TaggedHit const & a, TaggedHit const & b) {
-            return a.distance < b.distance;
-        });
+    if(!has_phi_cut_) {
         std::vector<Intersection> result;
         result.reserve(n_all);
         for(int i = 0; i < n_all; ++i) {
@@ -252,38 +230,54 @@ std::vector<Geometry::Intersection> Sphere::ComputeIntersections(
         return result;
     }
 
-    // Sort all hits by distance
+    // Phi cut: compute infinite wedge intersections (two half-planes from
+    // the z-axis). See Polycone.cxx for method description; same pattern in
+    // all phi-cut shapes.
+    bool z_axis_hit_emitted = false;
+    for(int face = 0; face < 2; ++face) {
+        double alpha = start_phi_ + face * delta_phi_;
+        double ca = std::cos(alpha), sa = std::sin(alpha);
+        double nx, ny;
+        if(face == 0) { nx = sa; ny = -ca; }
+        else { nx = -sa; ny = ca; }
+        double n_dot_d = nx*dx + ny*dy;
+        if(std::fabs(n_dot_d) < GEOMETRY_PRECISION) continue;
+        double n_dot_p = nx*px + ny*py;
+        double t = -n_dot_p / n_dot_d;
+        if(t > 0 && t < GEOMETRY_PRECISION) t = 0;
+
+        double hx = px + t*dx, hy = py + t*dy, hz = pz + t*dz;
+        if(hx*ca + hy*sa < -GEOMETRY_PRECISION) continue;
+
+        bool entering = (n_dot_d < 0);
+        if(hx*hx + hy*hy < GEOMETRY_PRECISION * 1e3 * GEOMETRY_PRECISION * 1e3) {
+            if(z_axis_hit_emitted) continue;
+            z_axis_hit_emitted = true;
+            entering = ZAxisWedgeEntering(dx, dy, start_phi_, delta_phi_);
+        }
+        all_hits[n_all] = {t, siren::math::Vector3D(hx, hy, hz), entering, 1};
+        n_all++;
+    }
+
+    if(n_all == 0) return {};
+
     std::sort(all_hits, all_hits + n_all, [](TaggedHit const & a, TaggedHit const & b) {
         return a.distance < b.distance;
     });
 
-    // Determine initial states at t = -infinity.
-    // Shell: always starts outside (finite closed surface).
-    // Phi wedge: determine from first wedge hit or PhiInRange check.
-    // Theta band: evaluate ThetaInRange along -direction (the t=-inf limit).
-    bool in_shell = false;
-    bool in_phi = !has_phi_cut_; // no phi cut means always "inside" the wedge
-    bool in_theta = !has_theta_cut_; // no theta cut means always "inside" the band
+    bool in_surface = false;
+    bool in_wedge = InitialPhiState(px, py, dx, dy, start_phi_, delta_phi_);
 
-    if(has_phi_cut_) {
-        in_phi = InitialPhiState(px, py, dx, dy, start_phi_, delta_phi_);
-    }
+    bool was_inside = in_surface && in_wedge;
 
-    if(has_theta_cut_) {
-        in_theta = ThetaInRange(-dx, -dy, -dz, start_theta_, delta_theta_);
-    }
-
-    bool was_inside = in_shell && in_phi && in_theta;
-
-    // CSG intersection walk
     std::vector<Intersection> result;
     for(int i = 0; i < n_all; ++i) {
-        switch(all_hits[i].source) {
-            case 0: in_shell = all_hits[i].entering; break;
-            case 1: in_phi = all_hits[i].entering; break;
-            case 2: in_theta = all_hits[i].entering; break;
+        if(all_hits[i].source == 0) {
+            in_surface = all_hits[i].entering;
+        } else {
+            in_wedge = all_hits[i].entering;
         }
-        bool now_inside = in_shell && in_phi && in_theta;
+        bool now_inside = in_surface && in_wedge;
         if(now_inside != was_inside) {
             Intersection isect;
             isect.distance = all_hits[i].distance;

--- a/projects/geometry/private/test/ShapeInvariants_TEST.cxx
+++ b/projects/geometry/private/test/ShapeInvariants_TEST.cxx
@@ -246,6 +246,14 @@ std::vector<ShapeEntry> MakeShapes() {
     // Polycone with step-change
     shapes.push_back({"PolyconeStep", Polycone({-0.05, 0.05, 0.05, 0.15}, {0, 0, 0, 0}, {0.03, 0.03, 0.05, 0.05}).create(), -1, -1, 0});
 
+    // Horn-like hollow conductor: the BNB horn inner conductors (HWL1/HRN1
+    // in the SBN model) are Polycones with centimeter radii, a narrow
+    // throat, and slope reversals at the joints.
+    shapes.push_back({"PolyconeHornLike",
+        Polycone({0.0, 0.5, 1.0, 1.5, 2.2, 3.0},
+                 {0.05, 0.02, 0.02, 0.05, 0.11, 0.15},
+                 {0.08, 0.05, 0.05, 0.08, 0.14, 0.18}).create(), -1, -1, 0});
+
     // Reversed z-planes (constructor auto-reverses to ascending)
     shapes.push_back({"PolyconeReversed", Polycone({5, 0, -5}, {0, 0, 0}, {3, 5, 3}).create(), -1, -1, 0});
     shapes.push_back({"PolyhedraReversed", Polyhedra(6, 0, {5, -5}, {0, 0}, {4, 4}).create(), -1, -1, 0});
@@ -740,6 +748,297 @@ TEST(ShapeInvariants, CylinderCapCornerSeamRays) {
                 ASSERT_GE(h.distance, lastd) << "ordering broken, ray " << i;
                 lastd = h.distance;
                 expect = !expect;
+            }
+        }
+    }
+}
+
+// =========================================================================
+// Polycone joint and theta-cut sphere seam sweeps
+// Same invariant as CylinderCapCornerSeamRays, for the remaining shapes
+// whose bounding surfaces meet at seam circles: rays grazing a seam must
+// never produce an unpaired hit, whatever the per-surface arithmetic does
+// on either side of the seam.
+// =========================================================================
+namespace {
+
+// Parity, alternation, and ordering of one intersection list; the
+// invariant every consumer of model-level intersections relies on.
+void ExpectSeamInvariants(std::vector<Geometry::Intersection> const & hits,
+                          std::string const & label) {
+    ASSERT_EQ(hits.size() % 2, 0u)
+        << label << ": unpaired hit count " << hits.size();
+    bool expect_entering = true;
+    double last = -std::numeric_limits<double>::infinity();
+    for(auto const & h : hits) {
+        ASSERT_EQ(h.entering, expect_entering) << label << ": alternation broken";
+        ASSERT_GE(h.distance, last) << label << ": ordering broken";
+        last = h.distance;
+        expect_entering = !expect_entering;
+    }
+}
+
+} // anonymous namespace
+
+// Rays grazing the joint circles of a polycone: the circles where adjacent
+// frustum sections meet (slope reversals, step flanges, bore joints) and
+// the end-cap corner circles. Three ray families per seam circle: arbitrary
+// incidence through a jittered seam point, near-tangent chords between two
+// nearby seam points, and rays born exactly on the jittered seam (the
+// GEANT-style birth-on-surface case that triggered the cylinder crash).
+// The millimeter-scale hollow profile is horn-like because the BNB horn
+// inner conductors (HWL1/HRN1 in the SBN model) are Polycones sitting
+// exactly where K0L birth-surface-grazing rays pass.
+TEST(ShapeInvariants, PolyconeJointSeamRays) {
+    struct Profile {
+        std::string name;
+        std::vector<double> zs, rmin, rmax;
+    };
+    std::vector<Profile> profiles = {
+        // Slope reversal at every internal joint
+        {"solid", {-5, -2, 0, 3, 5}, {0, 0, 0, 0, 0}, {3, 5, 4, 6, 2}},
+        // Hollow: bore joints add inner seam circles
+        {"hollow", {-4, 0, 4}, {1, 2, 1}, {5, 6, 5}},
+        // Duplicate z-planes: step flange with annular joint faces
+        {"step_flange", {-5, -2, -2, 2, 2, 5}, {0, 0, 0, 0, 0, 0}, {3, 3, 5, 5, 3, 3}},
+        // Horn-like hollow conductor: centimeter radii, narrow throat,
+        // slope reversals
+        {"horn_like", {0.0, 0.5, 1.0, 1.5, 2.2, 3.0},
+                      {0.05, 0.02, 0.02, 0.05, 0.11, 0.15},
+                      {0.08, 0.05, 0.05, 0.08, 0.14, 0.18}},
+    };
+
+    std::mt19937 seam_rng(20260725);
+    std::uniform_real_distribution<double> unit(-1.0, 1.0);
+    std::uniform_real_distribution<double> angle(0.0, 2.0 * M_PI);
+    auto rand_dir = [&]() {
+        double ux, uy, uz, mag;
+        do {
+            ux = unit(seam_rng); uy = unit(seam_rng); uz = unit(seam_rng);
+            mag = std::sqrt(ux*ux + uy*uy + uz*uz);
+        } while(mag < 1e-12);
+        return Vector3D(ux/mag, uy/mag, uz/mag);
+    };
+
+    for(auto const & prof : profiles) {
+        auto geo = Polycone(prof.zs, prof.rmin, prof.rmax).create();
+
+        // Seam circles: every (z-plane, radius) pair of the profile,
+        // including end-cap corners, step-flange edges, and bore joints.
+        std::vector<std::pair<double, double>> circles; // (z, r)
+        for(size_t k = 0; k < prof.zs.size(); ++k) {
+            circles.emplace_back(prof.zs[k], prof.rmax[k]);
+            if(prof.rmin[k] > 0) circles.emplace_back(prof.zs[k], prof.rmin[k]);
+        }
+
+        double scale = 0.0;
+        for(double r : prof.rmax) scale = std::max(scale, r);
+        double extent = prof.zs.back() - prof.zs.front();
+        double jit = 1e-6 * std::max(1.0, scale);
+        double reach = 2.0 * std::max(1.0, extent + scale);
+
+        for(size_t c = 0; c < circles.size(); ++c) {
+            double z0 = circles[c].first;
+            double r0 = circles[c].second;
+            for(int i = 0; i < 6000; ++i) {
+                double phi = angle(seam_rng);
+                Vector3D target((r0 + jit * unit(seam_rng)) * std::cos(phi),
+                                (r0 + jit * unit(seam_rng)) * std::sin(phi),
+                                z0 + jit * unit(seam_rng));
+                Vector3D origin, dir;
+                int family = i % 3;
+                if(family == 0) {
+                    // Arbitrary incidence through the jittered seam point
+                    origin = target + rand_dir() * reach;
+                    dir = target - origin;
+                } else if(family == 1) {
+                    // Near-tangent chord between two nearby seam points
+                    double phi2 = phi + 0.3 * std::fabs(unit(seam_rng)) + 1e-4;
+                    Vector3D p2((r0 + jit * unit(seam_rng)) * std::cos(phi2),
+                                (r0 + jit * unit(seam_rng)) * std::sin(phi2),
+                                z0 + jit * unit(seam_rng));
+                    dir = p2 - target;
+                    double mag = std::sqrt(dir.GetX()*dir.GetX() + dir.GetY()*dir.GetY() + dir.GetZ()*dir.GetZ());
+                    if(mag < 1e-12) continue;
+                    origin = target - (dir * (1.0 / mag)) * reach;
+                } else {
+                    // Ray born exactly on the jittered seam
+                    origin = target;
+                    dir = rand_dir();
+                }
+                double mag = std::sqrt(dir.GetX()*dir.GetX() + dir.GetY()*dir.GetY() + dir.GetZ()*dir.GetZ());
+                if(mag < 1e-12) continue;
+                dir = dir * (1.0 / mag);
+                auto hits = geo->Intersections(origin, dir);
+                ASSERT_NO_FATAL_FAILURE(ExpectSeamInvariants(hits,
+                    prof.name + " circle " + std::to_string(c) + " ray " + std::to_string(i)));
+            }
+        }
+    }
+}
+
+// Independent containment classifier for a partial sphere, used to check
+// that the material segments claimed by the intersection list are real.
+// Returns +1 (decisively inside), -1 (decisively outside), or 0 (within
+// `margin` of some boundary, too close to call). Boundary distances for
+// the angular cuts are chordal (angle times radius), so `margin` is a
+// length everywhere.
+namespace {
+int ClassifyPartialSphere(Vector3D const & p, double r_out, double r_in,
+                          double start_phi, double delta_phi,
+                          double start_theta, double delta_theta,
+                          double margin) {
+    double x = p.GetX(), y = p.GetY(), z = p.GetZ();
+    double r = std::sqrt(x*x + y*y + z*z);
+    double worst = r_out - r; // signed clearance: positive means inside
+    if(r_in > 0) worst = std::min(worst, r - r_in);
+    if(r < 20.0 * margin) {
+        // Too close to the apex: every angular boundary passes nearby.
+        return worst < -margin ? -1 : 0;
+    }
+    double theta = std::acos(std::min(1.0, std::max(-1.0, z / r)));
+    if(start_theta > 1e-9)
+        worst = std::min(worst, (theta - start_theta) * r);
+    if(start_theta + delta_theta < M_PI - 1e-9)
+        worst = std::min(worst, (start_theta + delta_theta - theta) * r);
+    if(delta_phi < 2.0 * M_PI - 1e-9) {
+        double rho = std::sqrt(x*x + y*y);
+        double dphi = std::atan2(y, x) - start_phi;
+        dphi = dphi - 2.0 * M_PI * std::floor(dphi / (2.0 * M_PI)); // to [0, 2pi)
+        // Signed angular clearance into the wedge, negative outside.
+        double a = std::min(dphi, delta_phi - dphi);
+        if(dphi > delta_phi) a = -std::min(dphi - delta_phi, 2.0 * M_PI - dphi);
+        worst = std::min(worst, a * rho);
+    }
+    if(worst > margin) return 1;
+    if(worst < -margin) return -1;
+    return 0;
+}
+} // anonymous namespace
+
+// Rays grazing the seam circles of a theta-cut sphere: the edge circles
+// where the theta cone faces meet the outer (and inner) spherical surface,
+// the equator edge of the half-space face at theta = pi/2, the cone apex
+// at the origin, and (for phi cuts) the wedge-plane edges. Same three ray
+// families as the polycone sweep; the apex is included as a degenerate
+// seam circle of zero radius.
+//
+// Parity alone cannot catch this shape's historical failure mode: the
+// per-root theta-cone tests fed a state walk whose output always
+// alternates, but a culled or misflagged cone root left the walk's band
+// state wrong for the rest of the ray, silently claiming material on
+// segments outside the band (or dropping real ones). So in addition to
+// the seam invariants, every claimed material segment (and every gap)
+// long enough to have a decisively classifiable midpoint is checked
+// against an independent containment predicate.
+TEST(ShapeInvariants, SphereThetaSeamRays) {
+    struct PartialSphere {
+        std::string name;
+        double r_out, r_in, start_phi, delta_phi, start_theta, delta_theta;
+    };
+    std::vector<PartialSphere> cases = {
+        {"cone45",      5, 0, 0, 2.0 * M_PI, 0,          M_PI / 4},
+        {"hollow_band", 5, 2, 0, 2.0 * M_PI, M_PI / 4,   M_PI / 2},
+        {"hemisphere",  5, 0, 0, 2.0 * M_PI, 0,          M_PI / 2},
+        {"band_mid",    5, 0, 0, 2.0 * M_PI, M_PI / 3,   M_PI / 3},
+        {"phi_theta",   5, 0, 0, M_PI,       M_PI / 4,   M_PI / 2},
+    };
+
+    std::mt19937 seam_rng(20260726);
+    std::uniform_real_distribution<double> unit(-1.0, 1.0);
+    std::uniform_real_distribution<double> angle(0.0, 2.0 * M_PI);
+    auto rand_dir = [&]() {
+        double ux, uy, uz, mag;
+        do {
+            ux = unit(seam_rng); uy = unit(seam_rng); uz = unit(seam_rng);
+            mag = std::sqrt(ux*ux + uy*uy + uz*uz);
+        } while(mag < 1e-12);
+        return Vector3D(ux/mag, uy/mag, uz/mag);
+    };
+
+    for(auto const & sc : cases) {
+        auto geo = Sphere(sc.r_out, sc.r_in, sc.start_phi, sc.delta_phi,
+                          sc.start_theta, sc.delta_theta).create();
+
+        // Seam circles (rho, z): active theta faces crossed with the outer
+        // and inner radii, plus the apex as a zero-radius circle.
+        std::vector<std::pair<double, double>> circles; // (rho, z)
+        std::vector<double> faces;
+        if(sc.start_theta > 1e-9) faces.push_back(sc.start_theta);
+        if(sc.start_theta + sc.delta_theta < M_PI - 1e-9)
+            faces.push_back(sc.start_theta + sc.delta_theta);
+        for(double theta0 : faces) {
+            circles.emplace_back(sc.r_out * std::sin(theta0), sc.r_out * std::cos(theta0));
+            if(sc.r_in > 0)
+                circles.emplace_back(sc.r_in * std::sin(theta0), sc.r_in * std::cos(theta0));
+        }
+        circles.emplace_back(0.0, 0.0); // cone apex
+
+        bool phi_cut = sc.delta_phi < 2.0 * M_PI - 1e-9;
+        double jit = 1e-6;
+        double reach = 4.0 * sc.r_out;
+
+        for(size_t c = 0; c < circles.size(); ++c) {
+            double rho0 = circles[c].first;
+            double z0 = circles[c].second;
+            for(int i = 0; i < 6000; ++i) {
+                double phi = angle(seam_rng);
+                // For phi-cut spheres, aim half the rays at the wedge-plane
+                // edges of the seam circle instead of a uniform azimuth.
+                if(phi_cut && (i & 1)) {
+                    phi = ((i & 2) ? sc.start_phi : sc.start_phi + sc.delta_phi)
+                          + 1e-6 * unit(seam_rng);
+                }
+                Vector3D target((rho0 + jit * unit(seam_rng)) * std::cos(phi),
+                                (rho0 + jit * unit(seam_rng)) * std::sin(phi),
+                                z0 + jit * unit(seam_rng));
+                Vector3D origin, dir;
+                int family = i % 3;
+                if(family == 0) {
+                    origin = target + rand_dir() * reach;
+                    dir = target - origin;
+                } else if(family == 1) {
+                    double phi2 = phi + 0.3 * std::fabs(unit(seam_rng)) + 1e-4;
+                    Vector3D p2((rho0 + jit * unit(seam_rng)) * std::cos(phi2),
+                                (rho0 + jit * unit(seam_rng)) * std::sin(phi2),
+                                z0 + jit * unit(seam_rng));
+                    dir = p2 - target;
+                    double mag = std::sqrt(dir.GetX()*dir.GetX() + dir.GetY()*dir.GetY() + dir.GetZ()*dir.GetZ());
+                    if(mag < 1e-12) continue;
+                    origin = target - (dir * (1.0 / mag)) * reach;
+                } else {
+                    origin = target;
+                    dir = rand_dir();
+                }
+                double mag = std::sqrt(dir.GetX()*dir.GetX() + dir.GetY()*dir.GetY() + dir.GetZ()*dir.GetZ());
+                if(mag < 1e-12) continue;
+                dir = dir * (1.0 / mag);
+                auto hits = geo->Intersections(origin, dir);
+                std::string label = sc.name + " circle " + std::to_string(c)
+                                    + " ray " + std::to_string(i);
+                ASSERT_NO_FATAL_FAILURE(ExpectSeamInvariants(hits, label));
+
+                // Midpoints of claimed material segments must be inside,
+                // midpoints of gaps must be outside, whenever the midpoint
+                // is decisively classifiable.
+                double margin = 1e-5 * sc.r_out;
+                for(size_t k = 0; k + 1 < hits.size(); ++k) {
+                    double len = hits[k + 1].distance - hits[k].distance;
+                    if(len < 1e-3 * sc.r_out) continue;
+                    double tm = 0.5 * (hits[k].distance + hits[k + 1].distance);
+                    Vector3D mid = origin + dir * tm;
+                    int cls = ClassifyPartialSphere(mid, sc.r_out, sc.r_in,
+                        sc.start_phi, sc.delta_phi, sc.start_theta, sc.delta_theta,
+                        margin);
+                    bool claimed_inside = hits[k].entering;
+                    if(claimed_inside) {
+                        ASSERT_NE(cls, -1) << label << ": claimed material segment "
+                            << k << " has an outside midpoint at t=" << tm;
+                    } else {
+                        ASSERT_NE(cls, 1) << label << ": claimed gap " << k
+                            << " has an inside midpoint at t=" << tm;
+                    }
+                }
             }
         }
     }

--- a/projects/geometry/private/test/ShapeInvariants_TEST.cxx
+++ b/projects/geometry/private/test/ShapeInvariants_TEST.cxx
@@ -673,6 +673,79 @@ TEST(ShapeInvariants, TangentRays) {
 }
 
 // =========================================================================
+// Cylinder cap/barrel corner seam
+// A ray crossing the neighborhood of the cap/barrel corner circle must
+// never produce an unpaired hit. The per-surface window tests used before
+// the interval method could cull a crossing's partner at the seam (the
+// barrel z-window and the cap r-window disagreeing about a corner
+// crossing), which broke enter/exit alternation and made
+// DetectorModel::SectorLoop abort with "Cannot exit a level that we have
+// not entered!". The exact ray below is the BNB target-rod configuration
+// recovered from a crashing SBND K0L injection: the kaon was born on the
+// rod's downstream corner, so the line through its decay vertex along its
+// momentum grazes the corner to within ~1e-7 m.
+// =========================================================================
+TEST(ShapeInvariants, CylinderCapCornerSeamRays) {
+    // BNB TARG rod dimensions; the placement in the detector model is a
+    // pure translation by (0, -5.6e-17, 0.390525), applied here directly
+    // to the ray (the 1e-17 y-offset is far below every margin in play).
+    double const rod_radius = 0.0047624999;
+    double const rod_length = 0.71120002;
+    auto targ = Cylinder(rod_radius, 0.0, rod_length).create();
+    {
+        Vector3D pos(-0.059748840138354575, -0.82280090677850126,
+                     2.1007794332370793 - 0.390525);
+        Vector3D dir(-0.039581487553593614, -0.52038274145986718,
+                     0.85301530363397216);
+        auto isects = targ->Intersections(pos, dir);
+        ASSERT_EQ(isects.size() % 2, 0u)
+            << "unpaired hit at the cap corner seam: " << isects.size();
+        bool expect_entering = true;
+        double last = -std::numeric_limits<double>::infinity();
+        for(auto const & h : isects) {
+            EXPECT_EQ(h.entering, expect_entering);
+            EXPECT_GE(h.distance, last);
+            last = h.distance;
+            expect_entering = !expect_entering;
+        }
+    }
+
+    // Sweep rays through the corner-circle neighborhood, solid and hollow
+    // rods: parity, alternation, and ordering must hold for every ray.
+    std::mt19937 seam_rng(20260724);
+    std::uniform_real_distribution<double> jitter(-1e-6, 1e-6);
+    std::uniform_real_distribution<double> angle(0.0, 2.0 * M_PI);
+    std::vector<std::shared_ptr<Geometry>> rods = {
+        Cylinder(rod_radius, 0.0, rod_length).create(),
+        Cylinder(rod_radius, 0.002, rod_length).create(),
+    };
+    double const hz = 0.5 * rod_length;
+    for(auto const & rod : rods) {
+        for(int i = 0; i < 20000; ++i) {
+            double phi = angle(seam_rng);
+            Vector3D corner((rod_radius + jitter(seam_rng)) * std::cos(phi),
+                            (rod_radius + jitter(seam_rng)) * std::sin(phi),
+                            (i % 2 ? hz : -hz) + jitter(seam_rng));
+            Vector3D offset = RandomDirection();
+            Vector3D origin = corner + offset * 2.0;
+            Vector3D d = corner - origin;
+            d.normalize();
+            auto hits = rod->Intersections(origin, d);
+            ASSERT_EQ(hits.size() % 2, 0u)
+                << "unpaired hit, ray " << i << ": " << hits.size();
+            bool expect = true;
+            double lastd = -std::numeric_limits<double>::infinity();
+            for(auto const & h : hits) {
+                ASSERT_EQ(h.entering, expect) << "alternation broken, ray " << i;
+                ASSERT_GE(h.distance, lastd) << "ordering broken, ray " << i;
+                lastd = h.distance;
+                expect = !expect;
+            }
+        }
+    }
+}
+
+// =========================================================================
 // Fix 3: Horizontal rays at Polycone/Polyhedra section boundaries
 // A horizontal ray exactly at an internal z-boundary must be claimed by
 // exactly one section (half-open interval [z_lo, z_hi)). Such a ray DOES


### PR DESCRIPTION
Ray intersection code for `Polycone` and the theta-cut `Sphere` paths tested each bounding surface independently, accepting a hit if it fell inside a tolerance window on some other coordinate. A ray grazing a seam where two surfaces meet could pass one window and fail another, so the returned hit list could contain an unpaired entry or exit. Every consumer of the model-level intersection list assumes entries and exits alternate, and `DetectorModel::SectorLoop` aborts such a walk with "Cannot exit a level that we have not entered!". In the non-throwing direction an unpaired entry is worse than a crash: it silently mis-attributes column and interaction-depth integrals.

31dbba1b fixed this for `Cylinder` with the interval method and explicitly flagged these two shapes as the remaining instances. They are not hypothetical: the BNB horn inner conductors (`HWL1`/`HRN1` in the SBN model) are polycones sitting exactly where the K0L rays that triggered the original crash pass, because GEANT places a neutral kaon's production point on the surface of the volume that produced it, so the line through its decay vertex grazes that surface to within floating-point noise.

## Approach

Both shapes now build the set of ray parameters inside the solid using exact interval algebra and emit each connected piece as an entry/exit pair, so parity holds by construction. A new private header, `RayIntervals.h`, carries the shared machinery: a small sorted list of disjoint intervals with exact intersection, union and subtraction; quadratic sign sets using the numerically stable root split; and half-lines whose complement shares its boundary parameter bit-for-bit.

**Polycone** composes each section as (z-slab ∩ outer cone ∖ inner cone) and unions the sections. The joint-plane ray parameter is computed once per plane index, so adjacent sections share it exactly: continuous joints coalesce during the merge, while step joints and end caps fall out as piece boundaries. The dedicated end-cap tests and the internal step-annulus block are deleted, as is the stack-to-heap hit buffer.

**Sphere** builds the theta band by set algebra instead of filtering individual cone roots. The condition that the polar angle stays below a limit is a z-halfspace combined with the sign set of `z² − cos²(θ)·|x|²`, where the squared form covers both nappes and the halfspace selects the correct one. Cone quadrics are evaluated about the ray's closest approach to the apex, where the squared apex distance is free of cancellation. Only the phi wedge remains a CSG state walk, consuming the interval endpoints as surface hits exactly as `Cylinder` does.

## A note on how this had to be tested

The sphere defect was invisible to parity checking, which is why it survived the first pass. The angular state walk always emits alternating output, so a culled or misflagged cone root simply left the band state wrong for the rest of the ray and quietly claimed material outside the band. The new sphere sweep therefore also checks the midpoint of every claimed material segment against an independent containment predicate, and that midpoint check is what fails against the previous implementation. The polycone sweep fails the previous implementation on parity directly, reporting an unpaired hit count of three.

Both sweeps walk every seam circle of their shapes with three ray families: arbitrary incidence through a jittered seam point, near-tangent chords between two nearby seam points, and rays born exactly on the seam. Both were confirmed red against the pre-rewrite sources before the rewrite was restored.

## Validation

Geometry suites pass at 59, 104, 27 and 25 tests for shape invariants, containment, operators and serialization. All nine detector suites pass, 345 tests, with no `SectorLoop` parity warning emitted anywhere in that run. Compilation is warning-free.

Separately, a fuzz over 3.2 million intersection calls on degenerate configurations found no violation of pairing, alternation, ordering or finiteness: cones tapering to a point, pinch-to-zero and zero-thickness profiles, discs of 1e-9, aspect ratios of 1e8, theta cuts of a microradian, spheres from 1e-6 to 1e7, denormal and zero direction z-components, non-normalized directions, and rays born exactly on joint planes and at the apex.

## Scope

The `SectorLoop` guard added by 31dbba1b stays. Its original rationale named these two shapes, but the remaining shapes still test their surfaces independently, and `Torus` retains a parity limitation that the shape suite already reports out loud from its quartic double-root handling. The guard's role narrows from a known-needed workaround to a general backstop.

This targets `main` and is independent of the open PR stack (#184 and #168–#185): nothing in that stack touches any file changed here, and trial merges against both the bottom and the tip of the stack are clean.
