### PR TITLE
Make resource loading safe for parallel jobs

### DIFF
--- a/python/_util.py
+++ b/python/_util.py
@@ -62,17 +62,8 @@ def log_newline(n=1):
     for handler, formatter in zip(logger.handlers, formatters):
         handler.setFormatter(formatter)
 
-# NOTE: do not import DarkNews at module scope here. Importing it pulls in
-# DarkNews.MC -> pandas -> numexpr, and numexpr starts a pool of native worker
-# threads at import. That would make every process multi-threaded merely by
-# virtue of "import siren", before any user code runs, which is precisely the
-# state in which fork() is unsafe: fork duplicates only the calling thread but
-# inherits the whole memory image, so any lock another thread happened to hold
-# is inherited locked and unlockable. Users running injections across a
-# multiprocessing Pool with the "fork" start method pay for that with
-# intermittent, silent deadlocks. DarkNews is imported lazily by the modules
-# that actually need it (SIREN_DarkNews, DNModelContainer) and probed by
-# siren.utilities.darknews_version(). Nothing in this module uses it.
+# NOTE: do not import DarkNews at module scope here
+# Importing DarNews.MC -> pandas -> numexpr breaks multi-threading
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/python/_util.py
+++ b/python/_util.py
@@ -1207,12 +1207,11 @@ def SaveEvents(events,
             datasets["num_secondaries"][-1].append(isec+1)
         datasets["num_interactions"].append(id+1)
 
-    # save events
-    # Imported here rather than at module scope: awkward starts native worker
-    # threads on import, and a multi-threaded process cannot safely fork().
-    # Only this function needs it. See the note next to THIS_DIR above.
+    # awkward must be imported here rather than at module scope
+    # causes issues with multi-threading otherwise
     import awkward as ak
 
+    # save events
     ak_array = ak.Array(datasets)
     if save_hdf5:
         fout = h5py.File(output_filename+".hdf5", "w")

--- a/python/_util.py
+++ b/python/_util.py
@@ -12,7 +12,6 @@ from siren import dataclasses as _dataclasses
 from siren import math as _math
 from siren.interactions import DarkNewsCrossSection,DarkNewsDecay
 import numpy as np
-import awkward as ak
 import h5py
 import pickle
 import logging
@@ -63,10 +62,17 @@ def log_newline(n=1):
     for handler, formatter in zip(logger.handlers, formatters):
         handler.setFormatter(formatter)
 
-try:
-    from DarkNews.nuclear_tools import NuclearTarget
-except:
-    pass
+# NOTE: do not import DarkNews at module scope here. Importing it pulls in
+# DarkNews.MC -> pandas -> numexpr, and numexpr starts a pool of native worker
+# threads at import. That would make every process multi-threaded merely by
+# virtue of "import siren", before any user code runs, which is precisely the
+# state in which fork() is unsafe: fork duplicates only the calling thread but
+# inherits the whole memory image, so any lock another thread happened to hold
+# is inherited locked and unlockable. Users running injections across a
+# multiprocessing Pool with the "fork" start method pay for that with
+# intermittent, silent deadlocks. DarkNews is imported lazily by the modules
+# that actually need it (SIREN_DarkNews, DNModelContainer) and probed by
+# siren.utilities.darknews_version(). Nothing in this module uses it.
 
 THIS_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -1211,6 +1217,11 @@ def SaveEvents(events,
         datasets["num_interactions"].append(id+1)
 
     # save events
+    # Imported here rather than at module scope: awkward starts native worker
+    # threads on import, and a multi-threaded process cannot safely fork().
+    # Only this function needs it. See the note next to THIS_DIR above.
+    import awkward as ak
+
     ak_array = ak.Array(datasets)
     if save_hdf5:
         fout = h5py.File(output_filename+".hdf5", "w")

--- a/python/download.py
+++ b/python/download.py
@@ -11,6 +11,9 @@ Public API
 writable_data_dir(module_dir)
     Return module_dir if writable, else a fallback under ~/.siren/.
 
+atomic_output_path(dest)
+    Context manager yielding a unique temp path renamed over dest on success.
+
 download_file(url, dest, sha256="")
     Download a single file with atomic write and optional SHA-256 check.
 
@@ -36,14 +39,22 @@ siren-download --fetch NAME        Pre-fetch data for one resource
 from __future__ import annotations
 
 import base64
+import contextlib
 import hashlib
 import json
 import os
 import sys
+import tempfile
 import urllib.error
 import urllib.request
 import zipfile
 from typing import Any
+
+# Read once, at import, so the temp-file permission fix below does not have to
+# flip the process umask at write time (os.umask is process-global and would
+# itself be a race in a threaded program).
+_UMASK = os.umask(0)
+os.umask(_UMASK)
 
 
 def writable_data_dir(module_dir: str) -> str:
@@ -107,23 +118,57 @@ def resolve_data_path(install_dir: str, download_dir: str,
 DEFAULT_TIMEOUT = 30  # seconds
 
 
+@contextlib.contextmanager
+def atomic_output_path(dest: str):
+    """Yield a temporary path to write, renamed over *dest* on clean exit.
+
+    The temporary name is unique per call, which is what makes the rename
+    actually atomic when several processes build the same file at once.
+    Writing through a shared, predictable name (``dest + ".tmp"``) is not
+    atomic despite the ``os.replace``: every process opens and truncates the
+    same inode, so their writes interleave, and the first process to rename
+    pulls the file out from under the others -- which then either fail with
+    ``FileNotFoundError`` or, worse, keep writing through their still-open
+    descriptor into the file now published at *dest*. Concurrent cold starts
+    of a resource loader hit exactly this.
+
+    On any exception the temporary is removed and the exception propagates,
+    so *dest* is left untouched rather than half-written.
+    """
+    directory = os.path.dirname(dest) or "."
+    os.makedirs(directory, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=directory,
+                               prefix=os.path.basename(dest) + ".",
+                               suffix=".tmp")
+    os.close(fd)
+    try:
+        yield tmp
+        # mkstemp creates 0600; widen to what a plain open() would have given
+        # so a cache built by one user stays readable in a shared install.
+        with contextlib.suppress(OSError):
+            os.chmod(tmp, 0o666 & ~_UMASK)
+        os.replace(tmp, dest)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.remove(tmp)
+        raise
+
+
 def download_file(url: str, dest: str, sha256: str = "",
                   label: str = "", show_progress: bool = True,
                   timeout: float = DEFAULT_TIMEOUT) -> None:
     """Download a file from *url* to *dest*.
 
-    - Atomic write: writes to a .tmp file, renames on success.
+    - Atomic write: writes to a per-call unique temp file, renames on
+      success, so concurrent downloads of the same file cannot collide.
     - Follows HTTP redirects (GitHub release assets, Zenodo CDN).
     - Optional SHA-256 verification.
     - Progress bar on stdout.
     """
-    os.makedirs(os.path.dirname(dest) or ".", exist_ok=True)
-    tmp = dest + ".tmp"
-
     if not label:
         label = os.path.basename(dest)
 
-    try:
+    with atomic_output_path(dest) as tmp:
         if show_progress:
             print(f"  Downloading {label} ...")
 
@@ -163,13 +208,6 @@ def download_file(url: str, dest: str, sha256: str = "",
                     f"SHA-256 mismatch for {label}:\n"
                     f"  expected: {sha256}\n"
                     f"  got:      {got}")
-
-        os.replace(tmp, dest)
-
-    except Exception:
-        if os.path.exists(tmp):
-            os.remove(tmp)
-        raise
 
 
 def ensure_files(specs: list[dict[str, Any]]) -> None:

--- a/resources/detectors/SBN/SBN-v1/sbn_loader.py
+++ b/resources/detectors/SBN/SBN-v1/sbn_loader.py
@@ -386,18 +386,13 @@ def ensure_miniboone_gdml(abs_dir: str,
     run before ``_ensure_gdml_files`` sees the MiniBooNE source spec.
     Returns the relative *filename* (matching the _DETECTOR_SPECS entry).
     """
+    from siren.download import atomic_output_path
+
     path = os.path.join(abs_dir, filename)
     if not os.path.isfile(path):
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        tmp = path + ".tmp"
-        try:
+        with atomic_output_path(path) as tmp:
             with open(tmp, "w", encoding="utf-8") as f:
                 f.write(_MINIBOONE_GDML)
-            os.replace(tmp, path)
-        except Exception:
-            if os.path.exists(tmp):
-                os.remove(tmp)
-            raise
     return filename
 
 
@@ -417,6 +412,8 @@ def build_composite(
 
     Returns the path to the written stub GDML.
     """
+    from siren.download import atomic_output_path
+
     cache_path = os.path.join(abs_dir, cache_name)
 
     _ensure_gdml_files(abs_dir, sources)
@@ -518,14 +515,8 @@ def build_composite(
 </gdml>
 """
 
-    tmp_path = cache_path + ".tmp"
-    try:
+    with atomic_output_path(cache_path) as tmp_path:
         with open(tmp_path, "w", encoding="utf-8") as f:
             f.write(stub)
-        os.replace(tmp_path, cache_path)
-    except Exception:
-        if os.path.exists(tmp_path):
-            os.remove(tmp_path)
-        raise
 
     return cache_path

--- a/resources/fluxes/Atmospheric/Atmospheric-v1.0/flux.py
+++ b/resources/fluxes/Atmospheric/Atmospheric-v1.0/flux.py
@@ -1,6 +1,7 @@
 import os
 import numpy as np
-from siren.download import ensure_files, writable_data_dir, resolve_data_path
+from siren.download import (atomic_output_path, ensure_files,
+                            resolve_data_path, writable_data_dir)
 
 _INSTALL_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -100,9 +101,8 @@ def load_flux(tag):
                 tot_flux += grid
 
     ee, cc = np.meshgrid(energy, cos_theta, indexing='ij')
-    tmp = output_flux_file + ".tmp"
-    np.savetxt(tmp,
-               np.column_stack([ee.ravel(), cc.ravel(), tot_flux.ravel()]))
-    os.replace(tmp, output_flux_file)
+    with atomic_output_path(output_flux_file) as tmp:
+        np.savetxt(tmp,
+                   np.column_stack([ee.ravel(), cc.ravel(), tot_flux.ravel()]))
 
     return output_flux_file

--- a/tests/python/test_download.py
+++ b/tests/python/test_download.py
@@ -360,3 +360,80 @@ class TestResolveDataPath:
         download.mkdir()
         # Absent from install_dir -> returns the download_dir path (regardless of existence there)
         assert dl.resolve_data_path(str(install), str(download), "missing.dat") == str(download / "missing.dat")
+
+
+# ======================================================================
+# atomic_output_path
+# ======================================================================
+
+class TestAtomicOutputPath:
+    """Concurrent writers must not share a temp filename.
+
+    Regression guard for a real failure: several processes calling
+    siren.load_detector() against a cold cache each wrote the composite GDML
+    through a fixed '<dest>.tmp' name. The first to rename pulled the file out
+    from under the rest, and most of them died with FileNotFoundError.
+    """
+
+    def test_writes_and_renames(self, tmp):
+        dest = tmp / "out.dat"
+        with dl.atomic_output_path(str(dest)) as t:
+            Path(t).write_text("payload")
+            assert not dest.exists(), "must not publish before the rename"
+        assert dest.read_text() == "payload"
+
+    def test_creates_missing_parent_directory(self, tmp):
+        dest = tmp / "nested" / "deeper" / "out.dat"
+        with dl.atomic_output_path(str(dest)) as t:
+            Path(t).write_text("x")
+        assert dest.read_text() == "x"
+
+    def test_error_leaves_dest_untouched_and_cleans_up(self, tmp):
+        dest = tmp / "out.dat"
+        dest.write_text("original")
+        with pytest.raises(RuntimeError):
+            with dl.atomic_output_path(str(dest)) as t:
+                Path(t).write_text("half written")
+                raise RuntimeError("boom")
+        assert dest.read_text() == "original"
+        assert list(tmp.iterdir()) == [dest], "temp file must be cleaned up"
+
+    def test_temp_name_is_unique_per_call(self, tmp):
+        dest = tmp / "out.dat"
+        with dl.atomic_output_path(str(dest)) as a:
+            with dl.atomic_output_path(str(dest)) as b:
+                assert a != b, "overlapping writers must not share a temp name"
+                Path(a).write_text("a")
+                Path(b).write_text("b")
+        assert dest.exists()
+
+    def test_concurrent_writers_all_succeed(self, tmp):
+        """Every writer completes and the destination holds one intact payload."""
+        dest = tmp / "composite.gdml"
+        nwriters = 12
+        # Large enough that writers are still writing while others rename.
+        def payload(tag):
+            return "".join(f"{tag:03d}" + "x" * 80 + "\n" for _ in range(20000))
+
+        errors: list[BaseException] = []
+
+        def writer(tag):
+            try:
+                with dl.atomic_output_path(str(dest)) as t:
+                    Path(t).write_text(payload(tag))
+            except BaseException as e:  # noqa: BLE001 - recorded and re-raised below
+                errors.append(e)
+
+        threads = [threading.Thread(target=writer, args=(i,))
+                   for i in range(nwriters)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"writers failed: {errors[:3]}"
+        text = dest.read_text()
+        tags = {line[:3] for line in text.splitlines() if line}
+        assert len(tags) == 1, "destination interleaves several writers' output"
+        assert text == payload(int(tags.pop())), "destination is truncated"
+        assert [p.name for p in tmp.iterdir()] == [dest.name], "temp files left behind"

--- a/tests/python/test_package_import.py
+++ b/tests/python/test_package_import.py
@@ -63,7 +63,7 @@ def test_resources_public_helpers():
 # another thread happened to hold is inherited locked and can never be
 # released. That turns a multiprocessing Pool using the "fork" start method
 # into an intermittent, silent deadlock. numexpr (16 threads, via
-# DarkNews -> pandas) and awkward (2 threads) were both on the import path.
+# DarkNews -> pandas) and awkward (2 threads) can both cause this issue.
 _THREAD_STARTING_MODULES = ("numexpr", "pandas", "awkward")
 
 def _run_probe(body):

--- a/tests/python/test_package_import.py
+++ b/tests/python/test_package_import.py
@@ -1,5 +1,8 @@
 """Smoke tests for the top-level siren package surface."""
 import importlib
+import subprocess
+import sys
+import textwrap
 
 import pytest
 
@@ -47,3 +50,70 @@ def test_resources_public_helpers():
         assert callable(getattr(resources, name)), f"siren.resources.{name} not callable"
     for name in ("fluxes", "detectors", "processes"):
         assert hasattr(resources, name), f"siren.resources missing {name}"
+
+
+# ======================================================================
+# Import must not make the process multi-threaded
+# ======================================================================
+
+# Modules that start native worker threads on import. Pulling any of them in
+# from siren's import path makes every SIREN process multi-threaded before user
+# code runs, and fork() is only safe from a single-threaded process: fork
+# duplicates the calling thread but inherits the whole memory image, so a lock
+# another thread happened to hold is inherited locked and can never be
+# released. That turns a multiprocessing Pool using the "fork" start method
+# into an intermittent, silent deadlock. numexpr (16 threads, via
+# DarkNews -> pandas) and awkward (2 threads) were both on the import path.
+_THREAD_STARTING_MODULES = ("numexpr", "pandas", "awkward")
+
+def _run_probe(body):
+    """Run *body* in a clean interpreter that has imported siren."""
+    out = subprocess.run([sys.executable, "-c", textwrap.dedent(body)],
+                         capture_output=True, text=True, timeout=300)
+    assert out.returncode == 0, f"probe failed:\n{out.stdout}\n{out.stderr}"
+    return out.stdout.strip()
+
+
+def test_import_does_not_pull_in_thread_starting_modules():
+    """siren must stay importable without starting background threads.
+
+    These are lazily imported by the code that needs them (awkward by
+    _util.SaveEvents, DarkNews by SIREN_DarkNews / DNModelContainer). Moving
+    any of them back to module scope reintroduces the fork hazard.
+    """
+    loaded = _run_probe(f"""
+        import sys
+        import siren
+        print(",".join(m for m in {_THREAD_STARTING_MODULES!r} if m in sys.modules))
+    """)
+    assert not loaded, (
+        f"'import siren' pulled in {loaded}, which start native worker threads "
+        "and make fork() unsafe; import them lazily where they are used")
+
+
+@pytest.mark.skipif(not hasattr(__import__("os"), "fork"),
+                    reason="requires POSIX fork()")
+def test_import_leaves_process_forkable():
+    """Forking after 'import siren' must not trip CPython's own warning.
+
+    CPython >= 3.12 warns when fork() is called from a multi-threaded process.
+    It counts OS-level threads, so unlike threading.active_count() this also
+    catches native pools started by extension modules -- which is exactly the
+    case that bit us.
+    """
+    result = _run_probe("""
+        import os, warnings
+        import siren
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pid = os.fork()
+            if pid == 0:
+                os._exit(0)
+            os.waitpid(pid, 0)
+        print(";".join(str(w.message) for w in caught
+                       if "multi-threaded" in str(w.message)))
+    """)
+    assert not result, (
+        f"fork() after 'import siren' is unsafe: {result}. A multi-threaded "
+        "process can inherit a held lock into the child, deadlocking "
+        "multiprocessing Pools that use the 'fork' start method")


### PR DESCRIPTION
Two independent defects that surfaced while running parallel injection jobs. Both make parallelism on a cluster or workstation fragile, and neither is specific to the setup that found them.

## Concurrent cache and download writes collide

Four places wrote a file by opening a fixed `<dest>.tmp` and renaming it over the destination: `download_file`, the SBN loader's `build_composite` and `ensure_miniboone_gdml`, and the Atmospheric flux loader. The rename is atomic; the scheme around it is not. Concurrent writers all open and truncate the same temp inode, so their writes interleave, and the first to rename pulls the file out from under the rest, which then die with `FileNotFoundError` or keep writing through a still-open descriptor into the file just published at the destination.

This is easy to hit: several processes calling `siren.load_detector` against a cold cache race on the composite GDML. Six concurrent cold starts left two of them dead. It happens for both the installed copy and the `~/.siren` user-data copy.

The fix adds `siren.download.atomic_output_path`, which allocates a unique temp file in the destination directory with `tempfile.mkstemp` and renames it into place, removing it on any exception so a failed write never leaves a partial destination. All four sites use it. `mkstemp` creates files 0600, so the mode is widened to what a plain `open()` would have given, sampling the umask once at import rather than flipping it at write time.

## Importing siren made every process multi-threaded

`_util` imported DarkNews at module scope for a `NuclearTarget` name it never used. That pulls in `DarkNews.MC` → pandas → numexpr, and numexpr starts sixteen native worker threads as a side effect of being imported. `awkward`, also at module scope but used only by `SaveEvents`, added two more. So `import siren` left the process with seventeen OS threads before any user code ran.

That is the precondition for a whole class of silent hangs. `fork()` duplicates only the calling thread while inheriting the entire address space, so a lock another thread happens to hold at that instant is inherited locked and can never be released — a `multiprocessing.Pool` using the `fork` start method can then deadlock with no error and no progress. CPython has warned about forking from a multi-threaded process since 3.12, and that warning was firing on every SIREN process.

Dropping the unused DarkNews import and moving `awkward` into `SaveEvents` brings the import down to a single thread and silences the warning. DarkNews is unaffected: `SIREN_DarkNews` and `DNModelContainer` import it directly, and `siren.utilities.darknews_version()` still probes for it.

To be clear about scope: this removes the precondition, not a demonstrated deadlock. Forked pools running real injections, injections in the parent before forking, and 200 stress forks with reader threads actively churning all completed cleanly, so there is no deterministic fork defect here to point at.

## Tests

Five cases in `test_download.py` cover `atomic_output_path`, including twelve concurrent writers, and two in `test_package_import.py` assert that importing siren pulls in no thread-starting module and that forking afterwards does not trip CPython's warning. Each was checked to fail against the unfixed code, so they are real guards rather than tests that cannot fail.

## Effect on the stack

Targets `main` deliberately rather than folding into the redesign stack: two of the four changed files are not touched by any stack branch, and this is an unrelated production fix. Replaying the current stack tip (`pr/s12-dutta-kim-physics`, 76 commits) over this branch produces exactly one conflict, in `tests/python/test_package_import.py`, where both sides append a block at the end of the file; the resolution is to keep both. Note that the local `pr/s*` branches are stale against an older main and will produce a spurious conflict in `distributions.cxx` if restacked without refreshing from origin first.