### PR TITLE
MARLEY.cmake: accept MARLEY_ROOT as a CMake cache variable

### DIFF
--- a/cmake/Packages/MARLEY.cmake
+++ b/cmake/Packages/MARLEY.cmake
@@ -26,7 +26,12 @@ set(_marley_ok TRUE)
 unset(MARLEY_PREFIX CACHE)
 unset(MARLEY_PREFIX)
 
-if(DEFINED ENV{MARLEY_ROOT} AND NOT "$ENV{MARLEY_ROOT}" STREQUAL "")
+# Precedence: MARLEY_ROOT cmake cache variable (persists across reconfigures,
+# set with -DMARLEY_ROOT=...) > MARLEY_ROOT environment variable > search.
+if(DEFINED MARLEY_ROOT AND NOT "${MARLEY_ROOT}" STREQUAL "")
+  set(MARLEY_PREFIX "${MARLEY_ROOT}")
+  message(STATUS "Using MARLEY_ROOT from CMake cache: ${MARLEY_PREFIX}")
+elseif(DEFINED ENV{MARLEY_ROOT} AND NOT "$ENV{MARLEY_ROOT}" STREQUAL "")
   set(MARLEY_PREFIX "$ENV{MARLEY_ROOT}")
   message(STATUS "Using MARLEY_ROOT from environment: ${MARLEY_PREFIX}")
 else()

--- a/cmake/Packages/MARLEY.cmake
+++ b/cmake/Packages/MARLEY.cmake
@@ -93,9 +93,6 @@ if(_marley_ok)
   endif()
 endif()
 
-# NOTE: Your current file sets include dir to "${prefix}/include/marley".
-# That only works if you include headers as <Particle.hh>.
-# If you include as <marley/Particle.hh> (typical), the include dir should be "${prefix}/include".
 if(_marley_ok)
   set(MARLEY_INCLUDE_DIR "${MARLEY_PREFIX}/include")
   if(NOT EXISTS "${MARLEY_INCLUDE_DIR}/marley/Generator.hh")


### PR DESCRIPTION
Tiny follow-up to #190. Automatic cmake reconfigures re-run the MARLEY finder, which only reads MARLEY_ROOT from the environment. If the current shell doesn't have it exported, MARLEY support is silently dropped (build succeeds, MarleyCrossSection missing, confusing AttributeError in python much later). This hit us in practice.

This adds -DMARLEY_ROOT=... as a cache variable (persists across reconfigures); precedence cache > env > search, env path unchanged.

Tip for reviewers: configuring with -DSIREN_REQUIRE_MARLEY=ON additionally turns any future loss of MARLEY into a loud configure failure, we now use both together.

Generated with [Claude Code](https://claude.com/claude-code)